### PR TITLE
Fix NPE for field resolver of Scalar / Enum type and Resolver operation name generation

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/batch/FieldResolverBatchLoader.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/batch/FieldResolverBatchLoader.java
@@ -20,6 +20,7 @@ import graphql.language.Document;
 import graphql.language.FragmentDefinition;
 import graphql.language.FragmentSpread;
 import graphql.language.OperationDefinition;
+import graphql.language.SelectionSet;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLSchema;
 import java.util.Collections;
@@ -30,6 +31,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.Builder;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.dataloader.BatchLoader;
 
@@ -95,6 +97,10 @@ public class FieldResolverBatchLoader implements BatchLoader<DataFetchingEnviron
   }
 
   private List<Definition<FragmentDefinition>> createResolverQueryFragmentDefinitions(DataFetchingEnvironment dataFetchingEnvironment) {
+    SelectionSet selectionSet = dataFetchingEnvironment.getField().getSelectionSet();
+    if (selectionSet == null || CollectionUtils.isEmpty(selectionSet.getSelections())) {
+      return Collections.emptyList();
+    }
     return dataFetchingEnvironment.getField().getSelectionSet().getSelections()
         .stream()
         .filter(selection -> selection instanceof FragmentSpread)

--- a/src/main/java/com/intuit/graphql/orchestrator/resolverdirective/FieldResolverDirectiveUtil.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/resolverdirective/FieldResolverDirectiveUtil.java
@@ -155,6 +155,9 @@ public class FieldResolverDirectiveUtil {
   }
 
   public static String createFieldResolverOperationName(String originalOperationName) {
+    if (StringUtils.isBlank(originalOperationName)) {
+      return RESOLVER_DIRECTIVE_QUERY_NAME.toString();
+    }
     return String.join(OPERATION_NAME_SEPARATOR, originalOperationName, RESOLVER_DIRECTIVE_QUERY_NAME);
   }
 }


### PR DESCRIPTION
# What Changed
- fix NPE if the output type of a field with @resolver is not a field container, i.e. scalar / enum
- If the original operation name does not have operation name, only use the defined constant.

