### PR TITLE
Supporting scalars defined in graphql-java > 16.x

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/utils/XtextToGraphQLJavaVisitor.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/utils/XtextToGraphQLJavaVisitor.java
@@ -204,6 +204,14 @@ public class XtextToGraphQLJavaVisitor extends GraphQLSwitch<GraphQLSchemaElemen
   @Override
   public GraphQLSchemaElement caseScalarTypeDefinition(final ScalarTypeDefinition object) {
     final String me = object.getName();
+    // Newer versions of graphql-java have removed inbuilt scalar support, so providers
+    // will need to define scalar in the sdl file. Since we are on old graphql-java,
+    // we need to handle the conflict of scalars defined in sdl with the ones defined
+    // in older graphql-java.
+    GraphQLScalarType inBuiltScalar = STANDARD_SCALAR_TYPES.get(me);
+    if(inBuiltScalar != null){
+      return inBuiltScalar;
+    }
 
     GraphQLType graphQLType = graphQLObjectTypes.get(me);
     if (Objects.nonNull(graphQLType)) {

--- a/src/test/java/com/intuit/graphql/orchestrator/stitching/StitcherTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/stitching/StitcherTest.java
@@ -195,6 +195,28 @@ public class StitcherTest {
   }
 
   @Test
+  public void makesCorrectGraphOnInBuiltScalar() {
+    String schema1 = "type Query { foo : Long }  ";
+    String schema2 = "type Query { bar : Long } scalar Long";
+
+    List<ServiceProvider> services = Arrays.asList(
+        TestServiceProvider.newBuilder().namespace("A").sdlFiles(ImmutableMap.of("schema1", schema1)).build(),
+        TestServiceProvider.newBuilder().namespace("B").sdlFiles(ImmutableMap.of("schema2", schema2)).build()
+    );
+
+    RuntimeGraph runtimeGraph = stitcher.stitch(services);
+    GraphQLObjectType query = runtimeGraph.getOperationMap().get(Operation.QUERY);
+    assertThat(query).isNotNull();
+
+    assertThat(query.getFieldDefinition("foo")).isNotNull();
+    assertThat(query.getFieldDefinition("bar")).isNotNull();
+
+    assertThat(query.getFieldDefinition("foo").getType())
+        .isEqualTo(query.getFieldDefinition("bar").getType());
+
+  }
+
+  @Test
   public void throwsExceptionOnGoldenTypeConflict() {
     String schema1 = "type Query { foo: PageInfo } type PageInfo { id: String }";
     String schema2 = "type Query { bar: PageInfo } type PageInfo { id: String }";


### PR DESCRIPTION
# What Changed
Inbuilt Scalars defined in the SDL file are now supported. This used to give a conflict error.

# Why
GraphQL-Java has dropped the support for inbuilt scalars in the engine. So people need to define it in the SDL file to use It. Examples include Long, BigDecimal, etc. Providers using graphql-java>16.x will not be able to consume the scalar using orchestrator, since we are still using graphql-java 14.1. It results in type conflict error. Now, with this change, we should be able to support scalars defined in both old and new graphql-java versions


Todo:

- [x] Add tests
- [ ] Add docs