### PR TITLE
Adding input type validation

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/utils/XtextToGraphQLJavaVisitor.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/utils/XtextToGraphQLJavaVisitor.java
@@ -2,6 +2,7 @@ package com.intuit.graphql.orchestrator.utils;
 
 import static com.intuit.graphql.orchestrator.utils.DirectivesUtil.DEPRECATED_DIRECTIVE;
 import static com.intuit.graphql.orchestrator.utils.DirectivesUtil.buildDeprecationReason;
+import static com.intuit.graphql.utils.XtextTypeUtils.typeName;
 import static java.util.Objects.requireNonNull;
 
 import com.intuit.graphql.graphQL.Argument;
@@ -359,6 +360,11 @@ public class XtextToGraphQLJavaVisitor extends GraphQLSwitch<GraphQLSchemaElemen
   private GraphQLArgument createGraphqlArgument(final InputValueDefinition object) {
     GraphQLArgument.Builder builder = GraphQLArgument.newArgument().name(object.getName())
         .description(object.getDesc());
+
+    if (!XtextTypeUtils.isValidInputType(object.getNamedType())) {
+      String typeName = typeName(object.getNamedType());
+      throw new SchemaParseException(String.format("Not a valid input type %s", typeName));
+    }
 
     GraphQLInputType type = (GraphQLInputType) doSwitch(object.getNamedType());
     builder.type(type);

--- a/src/main/java/com/intuit/graphql/orchestrator/utils/XtextTypeUtils.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/utils/XtextTypeUtils.java
@@ -126,4 +126,15 @@ public class XtextTypeUtils {
     }
     return StringUtils.EMPTY;
   }
+
+  public static boolean isValidInputType(NamedType namedType) {
+    //input fields are either scalars, enums, or other input objects
+    NamedType unwrappedNamedType = unwrapAll(namedType);
+    if (isObjectType(unwrappedNamedType)) {
+      TypeDefinition objectType = com.intuit.graphql.utils.XtextTypeUtils.getObjectType(unwrappedNamedType);
+      return (objectType instanceof InputObjectTypeDefinition) ||
+          (objectType instanceof EnumTypeDefinition);
+    }
+    return true;
+  }
 }

--- a/src/test/java/com/intuit/graphql/orchestrator/resolverdirective/FieldResolverDirectiveTestHelper.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/resolverdirective/FieldResolverDirectiveTestHelper.java
@@ -41,7 +41,7 @@ public class FieldResolverDirectiveTestHelper {
       + "union BUnionType "
       + "enum BEnumType "
       + "directive @resolver(field: String, arguments: [ResolverArgument!]) on FIELD_DEFINITION "
-      + "type ResolverArgument { name : String! value : String! }\n";
+      + "input ResolverArgument { name : String! value : String! }\n";
 
   public static final String bSchema = "type Query { "
       + "    b1 (id : String) : BObjectType "

--- a/src/test/java/com/intuit/graphql/orchestrator/utils/XtextTypeUtilsTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/utils/XtextTypeUtilsTest.java
@@ -7,12 +7,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.intuit.graphql.graphQL.ArgumentsDefinition;
 import com.intuit.graphql.graphQL.Directive;
 import com.intuit.graphql.graphQL.DirectiveDefinition;
+import com.intuit.graphql.graphQL.EnumTypeDefinition;
 import com.intuit.graphql.graphQL.FieldDefinition;
+import com.intuit.graphql.graphQL.InputObjectTypeDefinition;
 import com.intuit.graphql.graphQL.InputValueDefinition;
 import com.intuit.graphql.graphQL.ListType;
 import com.intuit.graphql.graphQL.NamedType;
 import com.intuit.graphql.graphQL.ObjectTypeDefinition;
+import com.intuit.graphql.graphQL.PrimitiveType;
+import com.intuit.graphql.graphQL.ScalarTypeDefinition;
 import com.intuit.graphql.orchestrator.xtext.GraphQLFactoryDelegate;
+import com.intuit.graphql.orchestrator.xtext.XtextScalars;
 import org.junit.Test;
 
 public class XtextTypeUtilsTest {
@@ -115,5 +120,43 @@ public class XtextTypeUtilsTest {
 
     assertThat(toDescriptiveString(fieldDefinition.getDirectives())).contains("directive1").contains("description1")
         .contains("directive2").contains("description2");
+  }
+
+  @Test
+  public void throwsExceptionForObjectTypeNotValidAsInput() {
+    ObjectTypeDefinition objectTypeDefinition = GraphQLFactoryDelegate.createObjectTypeDefinition();
+    objectTypeDefinition.setName("Arg1");
+    NamedType namedType = createNamedType(objectTypeDefinition);
+
+    ListType listType = GraphQLFactoryDelegate.createListType();
+    listType.setType(namedType);
+
+    assertThat(XtextTypeUtils.isValidInputType(listType)).isFalse();
+  }
+
+  @Test
+  public void InputObjectTypeIsValidAsInput() {
+    InputObjectTypeDefinition inputObjectTypeDefinition = GraphQLFactoryDelegate.createInputObjectTypeDefinition();
+    inputObjectTypeDefinition.setName("Arg1");
+    NamedType namedType = createNamedType(inputObjectTypeDefinition);
+
+    ListType listType = GraphQLFactoryDelegate.createListType();
+    listType.setType(namedType);
+    assertThat(XtextTypeUtils.isValidInputType(listType)).isTrue();
+  }
+
+  @Test
+  public void EnumTypeIsValidAsInput() {
+    EnumTypeDefinition enumTypeDefinition = GraphQLFactoryDelegate.createEnumTypeDefinition();
+    enumTypeDefinition.setName("Arg1");
+    NamedType namedType = createNamedType(enumTypeDefinition);
+    assertThat(XtextTypeUtils.isValidInputType(namedType)).isTrue();
+  }
+
+  @Test
+  public void ScalarTypeIsValidAsInput() {
+    PrimitiveType primitiveType = GraphQLFactoryDelegate.createPrimitiveType();
+    primitiveType.setType("String");
+    assertThat(XtextTypeUtils.isValidInputType(primitiveType)).isTrue();
   }
 }

--- a/src/test/resources/nested/books-pets-person/pet-author-link.graphqls
+++ b/src/test/resources/nested/books-pets-person/pet-author-link.graphqls
@@ -10,7 +10,7 @@ type Pet {}
 directive @resolver(field: String!, arguments: [ResolverArgument!]) on FIELD_DEFINITION
 
 # define this as built-in type
-type ResolverArgument {
+input ResolverArgument {
     name : String!
     value : String!
 }


### PR DESCRIPTION
# What Changed

Adding input type validation in XtextToGraphQLJavaVisitor.  

# Why

Currently, when object type is wrapped in a List and used as an input creating runtime schema is not able to detect this error.

The issue occurs when an argument uses a GraphQLList(an instance of GraphQLInputType) and wraps a non-input type like GraphQLObjectType.  
`graphql-java` provides deep check in SchemaGenerator class but this is not used to generate runtime schema.  The builders like `GraphQLArgument.Builder` and `GraphQLSchema.newSchema()` does not do deeper checks.

Todo:

- [x] Add tests