### PR TITLE
adding ScalarTypeDefinition in input type validation

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/utils/XtextTypeUtils.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/utils/XtextTypeUtils.java
@@ -133,6 +133,7 @@ public class XtextTypeUtils {
     if (isObjectType(unwrappedNamedType)) {
       TypeDefinition objectType = com.intuit.graphql.utils.XtextTypeUtils.getObjectType(unwrappedNamedType);
       return (objectType instanceof InputObjectTypeDefinition) ||
+          (objectType instanceof ScalarTypeDefinition) ||
           (objectType instanceof EnumTypeDefinition);
     }
     return true;

--- a/src/test/java/com/intuit/graphql/orchestrator/utils/XtextTypeUtilsTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/utils/XtextTypeUtilsTest.java
@@ -159,4 +159,12 @@ public class XtextTypeUtilsTest {
     primitiveType.setType("String");
     assertThat(XtextTypeUtils.isValidInputType(primitiveType)).isTrue();
   }
+
+  @Test
+  public void ScalarTypeDefinitionIsValidAsInput() {
+    ScalarTypeDefinition scalarTypeDefinition = GraphQLFactoryDelegate.createScalarTypeDefinition();
+    scalarTypeDefinition.setName("TestScalar");
+    NamedType namedType = createNamedType(scalarTypeDefinition);
+    assertThat(XtextTypeUtils.isValidInputType(namedType)).isTrue();
+  }
 }


### PR DESCRIPTION
# What Changed
Add ScalarTypeDefinition in input type validation.  

# Why
This existing validation does not cover it where it should be.

Todo:

- [x] Add tests
- [ ] Add docs