### PR TITLE
adding output type validation for @resolver at schema build time

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMerge.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMerge.java
@@ -76,7 +76,7 @@ public class FieldResolverTransformerPostMerge implements Transformer<XtextGraph
     NamedType targetFieldType = targetFieldDefinition.getNamedType();
 
     if (!XtextTypeUtils.isCompatible(fieldResolverType, targetFieldType)) {
-      String errorMessage = "Field resolver type does not match the type of target field.";
+      String errorMessage = "The type of field with @resolver is not compatible with target field type.";
       throw new FieldResolverException(errorMessage, fieldResolverContext);
     }
   }

--- a/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMerge.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMerge.java
@@ -32,6 +32,8 @@ public class FieldResolverTransformerPostMerge implements Transformer<XtextGraph
     if (CollectionUtils.isNotEmpty(sourceXtextGraph.getFieldResolverContexts())) {
       List<FieldResolverContext> fieldResolverContexts = sourceXtextGraph.getFieldResolverContexts()
               .stream()
+              .peek(fieldResolverContext -> validateTargetTypeExists(fieldResolverContext,sourceXtextGraph))
+              .peek(fieldResolverContext -> validateFieldResolverType(fieldResolverContext,sourceXtextGraph))
               .peek(fieldResolverContext -> replacePlaceholderTypeWithActual(fieldResolverContext, sourceXtextGraph))
               .map(fieldResolverContext -> updateWithTargetFieldData(fieldResolverContext, sourceXtextGraph))
               .collect(Collectors.toList());
@@ -48,8 +50,35 @@ public class FieldResolverTransformerPostMerge implements Transformer<XtextGraph
 
       return newXtextGraph;
     }
-
     return sourceXtextGraph;
+  }
+
+  private void validateTargetTypeExists(FieldResolverContext fieldResolverContext, XtextGraph sourceXtextGraph) {
+    FieldDefinition fieldDefinition = fieldResolverContext.getFieldDefinition();
+    NamedType fieldType = fieldDefinition.getNamedType();
+    if (!XtextTypeUtils.isPrimitiveType(fieldType)) {
+      TypeDefinition actualTypeDefinition = sourceXtextGraph.getType(fieldType);
+      if (Objects.isNull(actualTypeDefinition)) {
+        String serviceName = fieldResolverContext.getServiceNamespace();
+        String parentTypeName = XtextTypeUtils.getParentTypeName(fieldDefinition);
+        String fieldName = fieldDefinition.getName();
+        String placeHolderTypeDescription = XtextUtils.toDescriptiveString(fieldType);
+
+        throw new ExternalTypeNotfoundException(serviceName, parentTypeName, fieldName, placeHolderTypeDescription);
+      }
+    }
+  }
+
+  private void validateFieldResolverType(FieldResolverContext fieldResolverContext, XtextGraph sourceXtextGraph) {
+    final ResolverDirectiveDefinition resolverDirectiveDefinition = fieldResolverContext.getResolverDirectiveDefinition();
+    final FieldDefinition targetFieldDefinition = getFieldDefinitionByFQN(resolverDirectiveDefinition.getField(), sourceXtextGraph);
+    NamedType fieldResolverType = fieldResolverContext.getFieldDefinition().getNamedType();
+    NamedType targetFieldType = targetFieldDefinition.getNamedType();
+
+    if (!XtextTypeUtils.compareTypes(fieldResolverType, targetFieldType)) {
+      String errorMessage = "Field resolver type does not match the type of target field.";
+      throw new FieldResolverException(errorMessage, fieldResolverContext);
+    }
   }
 
   private FieldResolverContext updateWithTargetFieldData(final FieldResolverContext fieldResolverContext, final XtextGraph sourceXtextGraph) {
@@ -131,14 +160,6 @@ public class FieldResolverTransformerPostMerge implements Transformer<XtextGraph
 
     if (!XtextTypeUtils.isPrimitiveType(fieldType)) {
       TypeDefinition actualTypeDefinition = sourceXtextGraph.getType(fieldType);
-      if (Objects.isNull(actualTypeDefinition)) {
-        String serviceName = fieldResolverContext.getServiceNamespace();
-        String parentTypeName = XtextTypeUtils.getParentTypeName(fieldDefinition);
-        String fieldName = fieldDefinition.getName();
-        String placeHolderTypeDescription = XtextUtils.toDescriptiveString(fieldType);
-
-        throw new ExternalTypeNotfoundException(serviceName, parentTypeName, fieldName, placeHolderTypeDescription);
-      }
 
       if (XtextTypeUtils.isObjectType(fieldType)) {
         fieldDefinition.setNamedType(createNamedType(actualTypeDefinition));

--- a/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMerge.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMerge.java
@@ -75,7 +75,7 @@ public class FieldResolverTransformerPostMerge implements Transformer<XtextGraph
     NamedType fieldResolverType = fieldResolverContext.getFieldDefinition().getNamedType();
     NamedType targetFieldType = targetFieldDefinition.getNamedType();
 
-    if (!XtextTypeUtils.compareTypes(fieldResolverType, targetFieldType)) {
+    if (!XtextTypeUtils.isCompatible(fieldResolverType, targetFieldType)) {
       String errorMessage = "Field resolver type does not match the type of target field.";
       throw new FieldResolverException(errorMessage, fieldResolverContext);
     }

--- a/src/main/java/com/intuit/graphql/orchestrator/utils/XtextTypeUtils.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/utils/XtextTypeUtils.java
@@ -103,6 +103,21 @@ public class XtextTypeUtils {
     return StringUtils.equals(typeName(lType), typeName(rType));
   }
 
+  public static boolean isCompatible(NamedType stubType, NamedType targetType) {
+    if (isWrapped(stubType) != isWrapped(targetType)) {
+      return false;
+    }
+    if (isWrapped(stubType) && isWrapped(targetType)) {
+      return isCompatible(unwrapOne(stubType), unwrapOne(targetType));
+    }
+    if (isNonNull(stubType) && !isNonNull(targetType)) {
+      // e.g. stubType=A! targetType=A
+      // subtype should be less restrictive
+      return false;
+    }
+    return StringUtils.equals(typeName(stubType), typeName(targetType));
+  }
+
   public static String toDescriptiveString(ArgumentsDefinition argumentsDefinition) {
     if (Objects.nonNull(argumentsDefinition)) {
       StringBuilder result = new StringBuilder();

--- a/src/test/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMergeTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMergeTest.java
@@ -575,7 +575,7 @@ public class FieldResolverTransformerPostMergeTest {
 
     assertThat(placeHolderTypeDefinition).isNotSameAs(externalObjectTypeDefinition);
 
-    String expectedMessage = "Field resolver type does not match the type of target field.  "
+    String expectedMessage = "The type of field with @resolver is not compatible with target field type.  "
         + "fieldName=a,  parentTypeName=AObjectType,  "
         + "resolverDirectiveDefinition=ResolverDirectiveDefinition(field=b1, arguments=[ResolverArgumentDefinition(name=id, value=$af1)])";
     exceptionRule.expect(FieldResolverException.class);


### PR DESCRIPTION
# What Changed
adding compatibility checking for field resolver.  A type is compatible with another type types are the same tor if the the source/target type is more restrict.  e.g. stub type **A** is compatible with target type **A!** but not the other way around.

Todo:
- [x] Add tests
- [ ] Add docs