### PR TITLE
Adding a virtual provider for empty graphql support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     <awssdk2.version>2.7.2</awssdk2.version>
-    <graphql-sdl-version>3.0.1</graphql-sdl-version>
+    <graphql-sdl-version>3.0.1-SNAPSHOT</graphql-sdl-version>
     <xtextVersion>2.25.0</xtextVersion>
     <graphQLVersion>17.3</graphQLVersion>
   </properties>

--- a/src/main/java/com/intuit/graphql/orchestrator/VirtualOrchestratorProvider.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/VirtualOrchestratorProvider.java
@@ -1,0 +1,37 @@
+package com.intuit.graphql.orchestrator;
+
+import graphql.ExecutionInput;
+import graphql.GraphQLContext;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+public class VirtualOrchestratorProvider implements ServiceProvider {
+
+  public static final String ORCHESTRATOR = "ORCHESTRATOR";
+  public static final String FIELD_NAME = "_namespace";
+  public static final String SDL = String.format("type Query { %s : String }", FIELD_NAME);
+  public static final String FILE_NAME = String.format("%s.graphqls", ORCHESTRATOR);
+
+  @Override
+  public String getNameSpace() {
+    return ORCHESTRATOR;
+  }
+
+  @Override
+  public Map<String, String> sdlFiles() {
+    return createMap(FILE_NAME, SDL);
+  }
+
+  @Override
+  public CompletableFuture<Map<String, Object>> query(final ExecutionInput executionInput,
+      final GraphQLContext context) {
+    return CompletableFuture.completedFuture(createMap("data",createMap(FIELD_NAME, ORCHESTRATOR)));
+  }
+
+  private <T> Map<String, T> createMap(String key, T value) {
+    final Map<String, T> sdlFiles = new HashMap<String, T>();
+    sdlFiles.put(key, value);
+    return sdlFiles;
+  }
+}

--- a/src/main/java/com/intuit/graphql/orchestrator/VirtualOrchestratorProvider.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/VirtualOrchestratorProvider.java
@@ -12,6 +12,9 @@ public class VirtualOrchestratorProvider implements ServiceProvider {
   public static final String FIELD_NAME = "_namespace";
   public static final String SDL = String.format("type Query { %s : String }", FIELD_NAME);
   public static final String FILE_NAME = String.format("%s.graphqls", ORCHESTRATOR);
+  public static final ServiceProvider INSTANCE = new VirtualOrchestratorProvider();
+
+  private VirtualOrchestratorProvider(){}
 
   @Override
   public String getNameSpace() {

--- a/src/main/java/com/intuit/graphql/orchestrator/VirtualOrchestratorProvider.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/VirtualOrchestratorProvider.java
@@ -20,18 +20,18 @@ public class VirtualOrchestratorProvider implements ServiceProvider {
 
   @Override
   public Map<String, String> sdlFiles() {
-    return createMap(FILE_NAME, SDL);
+    return createData(FILE_NAME, SDL);
   }
 
   @Override
   public CompletableFuture<Map<String, Object>> query(final ExecutionInput executionInput,
       final GraphQLContext context) {
-    return CompletableFuture.completedFuture(createMap("data",createMap(FIELD_NAME, ORCHESTRATOR)));
+    return CompletableFuture.completedFuture(createData("data",createData(FIELD_NAME, ORCHESTRATOR)));
   }
 
-  private <T> Map<String, T> createMap(String key, T value) {
-    final Map<String, T> sdlFiles = new HashMap<String, T>();
-    sdlFiles.put(key, value);
-    return sdlFiles;
+  private static <T> Map<String, T> createData(String key, T value) {
+    final Map<String, T> dataMap = new HashMap<String, T>();
+    dataMap.put(key, value);
+    return dataMap;
   }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/schema/RuntimeGraph.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/schema/RuntimeGraph.java
@@ -51,22 +51,6 @@ public class RuntimeGraph {
     return new Builder();
   }
 
-  /**
-   * Empty runtime graph.
-   *
-   * @return the runtime graph
-   */
-  public static RuntimeGraph emptyGraph() {
-
-    Map<Operation, GraphQLObjectType> newMap = new EnumMap<>(Operation.class);
-    for (Operation op : Operation.values()) {
-      newMap.put(op, op.asGraphQLObjectType());
-    }
-    return new Builder()
-        .operationMap(newMap)
-        .build();
-  }
-
   public GraphQLType getType(String name) {
     return graphQLtypes.getOrDefault(name, additionalTypes.get(name));
   }

--- a/src/main/java/com/intuit/graphql/orchestrator/stitching/SchemaStitcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/stitching/SchemaStitcher.java
@@ -54,7 +54,7 @@ public class SchemaStitcher {
   public static final class Builder {
 
     private BatchLoaderExecutionHooks<DataFetchingEnvironment, DataFetcherResult<Object>> batchLoaderHooks = BatchLoaderExecutionHooks.DEFAULT_HOOKS;
-    private List<ServiceProvider> serviceProviders = new ArrayList<>(Arrays.asList(new VirtualOrchestratorProvider()));
+    private List<ServiceProvider> serviceProviders = new ArrayList<>(Arrays.asList(VirtualOrchestratorProvider.INSTANCE));
 
     private Builder() {
     }

--- a/src/main/java/com/intuit/graphql/orchestrator/stitching/SchemaStitcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/stitching/SchemaStitcher.java
@@ -3,12 +3,14 @@ package com.intuit.graphql.orchestrator.stitching;
 import static java.util.Objects.requireNonNull;
 
 import com.intuit.graphql.orchestrator.ServiceProvider;
+import com.intuit.graphql.orchestrator.VirtualOrchestratorProvider;
 import com.intuit.graphql.orchestrator.batch.BatchLoaderExecutionHooks;
 import com.intuit.graphql.orchestrator.schema.RuntimeGraph;
 import graphql.VisibleForTesting;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
 
@@ -52,7 +54,7 @@ public class SchemaStitcher {
   public static final class Builder {
 
     private BatchLoaderExecutionHooks<DataFetchingEnvironment, DataFetcherResult<Object>> batchLoaderHooks = BatchLoaderExecutionHooks.DEFAULT_HOOKS;
-    private List<ServiceProvider> serviceProviders = new ArrayList<>();
+    private List<ServiceProvider> serviceProviders = new ArrayList<>(Arrays.asList(new VirtualOrchestratorProvider()));
 
     private Builder() {
     }

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/TopLevelStitchingSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/TopLevelStitchingSpec.groovy
@@ -52,7 +52,7 @@ class TopLevelStitchingSpec extends BaseIntegrationTestSpecification {
         personService = createSimpleMockService("PERSON", TestHelper.getResourceAsString("top_level/person/schema1.graphqls"), mockPersonServiceResponse)
     }
 
-    def "Orchestrator works without any provider"() {
+    def "Orchestrator works without any downstream service provider"() {
         given:
         specUnderTest = createGraphQLOrchestrator([])
 

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/TopLevelStitchingSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/TopLevelStitchingSpec.groovy
@@ -1,10 +1,14 @@
 package com.intuit.graphql.orchestrator.integration
 
 import com.intuit.graphql.orchestrator.TestHelper
+import com.intuit.graphql.orchestrator.VirtualOrchestratorProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import helpers.BaseIntegrationTestSpecification
 import spock.lang.Subject
+
+import static com.intuit.graphql.orchestrator.VirtualOrchestratorProvider.FIELD_NAME
+import static com.intuit.graphql.orchestrator.VirtualOrchestratorProvider.ORCHESTRATOR
 
 class TopLevelStitchingSpec extends BaseIntegrationTestSpecification {
     def epsService, epsMutationService, personService
@@ -46,6 +50,24 @@ class TopLevelStitchingSpec extends BaseIntegrationTestSpecification {
         epsService = createSimpleMockService( "EPS", TestHelper.getResourceAsString("top_level/eps/schema2.graphqls"), mockEpsServiceResponse)
         epsMutationService = createSimpleMockService( "EPS", TestHelper.getResourceAsString("top_level/eps/schema2.graphqls"), mockEpsServiceMutationResponse)
         personService = createSimpleMockService("PERSON", TestHelper.getResourceAsString("top_level/person/schema1.graphqls"), mockPersonServiceResponse)
+    }
+
+    def "Orchestrator works without any provider"() {
+        given:
+        specUnderTest = createGraphQLOrchestrator([])
+
+        def graphqlQuery = "{ ${FIELD_NAME} }"
+
+        ExecutionInput executionInput = createExecutionInput(graphqlQuery)
+
+        when:
+        ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
+
+        then:
+        executionResult.getErrors().isEmpty()
+        Map<String, Object> data = executionResult.getData()
+        data?._namespace instanceof String && data?._namespace == ORCHESTRATOR
+
     }
 
     def "Person service is stitched and queried"() {

--- a/src/test/java/com/intuit/graphql/orchestrator/GraphQLOrchestratorTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/GraphQLOrchestratorTest.java
@@ -62,8 +62,8 @@ public class GraphQLOrchestratorTest {
     }
   };
 
-  @Test(expected = InvalidSchemaException.class)
-  public void testBuilder() {
+  @Test
+  public void testBuilderWithoutService() {
     final Builder baseBuilder = GraphQLOrchestrator.newOrchestrator();
     assertThatThrownBy(() -> baseBuilder.queryExecutionStrategy(null))
         .isInstanceOf(NullPointerException.class);


### PR DESCRIPTION
# What Changed
* Adding a virtual provider with a _namespace field 

# Why
* graphql-java 17.3 does not allow Query Object without fields.

Todo:

- [x] Add tests
- [x] Add docs