### PR TITLE
Adding support for nested field resolver

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/batch/NoExternalReferenceSelectionSetModifier.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/batch/NoExternalReferenceSelectionSetModifier.java
@@ -15,6 +15,7 @@ import graphql.language.FragmentDefinition;
 import graphql.language.InlineFragment;
 import graphql.language.Node;
 import graphql.language.NodeVisitorStub;
+import graphql.language.OperationDefinition;
 import graphql.language.SelectionSet;
 import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLFieldDefinition;
@@ -86,6 +87,12 @@ public class NoExternalReferenceSelectionSetModifier extends NodeVisitorStub {
   public TraversalControl visitInlineFragment(InlineFragment node, TraverserContext<Node> context) {
     GraphQLType parentType = getParentType(context);
     context.setVar(GraphQLType.class, parentType);
+    return TraversalControl.CONTINUE;
+  }
+
+  @Override
+  public TraversalControl visitOperationDefinition(OperationDefinition node, TraverserContext<Node> context) {
+    context.setVar(GraphQLType.class, rootType);
     return TraversalControl.CONTINUE;
   }
 

--- a/src/main/java/com/intuit/graphql/orchestrator/fieldresolver/FieldResolverGraphQLError.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/fieldresolver/FieldResolverGraphQLError.java
@@ -1,0 +1,73 @@
+package com.intuit.graphql.orchestrator.fieldresolver;
+
+import com.intuit.graphql.orchestrator.resolverdirective.ResolverDirectiveDefinition;
+import graphql.ErrorType;
+import graphql.GraphqlErrorException;
+
+/**
+ * A class thrown when an error occured during field resolver graphql execution
+ */
+public class FieldResolverGraphQLError extends GraphqlErrorException {
+
+  private FieldResolverGraphQLError(FieldResolverGraphQLError.Builder builder) {
+    super(builder);
+  }
+
+  @Override
+  public ErrorType getErrorType() {
+    return ErrorType.ExecutionAborted;
+  }
+
+  public static FieldResolverGraphQLError.Builder builder() {
+    return new FieldResolverGraphQLError.Builder();
+  }
+
+  public static class Builder extends BuilderBase<FieldResolverGraphQLError.Builder, FieldResolverGraphQLError> {
+
+    private String errorMessage;
+
+    private String fieldName;
+    private String parentTypeName;
+    private ResolverDirectiveDefinition resolverDirectiveDefinition;
+    private String serviceNameSpace;
+
+    public Builder fieldName(String fieldName) {
+      this.fieldName = fieldName;
+      return this;
+    }
+
+    public Builder parentTypeName(String parentTypeName) {
+      this.parentTypeName = parentTypeName;
+      return this;
+    }
+
+    public Builder resolverDirectiveDefinition(ResolverDirectiveDefinition resolverDirectiveDefinition) {
+      this.resolverDirectiveDefinition = resolverDirectiveDefinition;
+      return this;
+    }
+
+    public Builder serviceNameSpace(String serviceNameSpace) {
+      this.serviceNameSpace = serviceNameSpace;
+      return this;
+    }
+
+    public Builder errorMessage(String errorMessage) {
+      this.errorMessage = errorMessage;
+      return this;
+    }
+
+    public FieldResolverGraphQLError build() {
+      String msgTemplate = "%s. "
+          + " fieldName=%s, "
+          + " parentTypeName=%s, "
+          + " resolverDirectiveDefinition=%s,"
+          + " serviceNameSpace=%s";
+
+      this.message = String.format(msgTemplate, errorMessage, fieldName, parentTypeName,
+          resolverDirectiveDefinition, serviceNameSpace);
+      this.errorClassification = ErrorType.DataFetchingException;
+      return new FieldResolverGraphQLError(this);
+    }
+  }
+
+}

--- a/src/main/java/com/intuit/graphql/orchestrator/fieldresolver/QueryOperationFactory.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/fieldresolver/QueryOperationFactory.java
@@ -4,14 +4,12 @@ import graphql.language.OperationDefinition;
 import graphql.language.OperationDefinition.Operation;
 import graphql.language.SelectionSet;
 
-import java.util.function.Supplier;
-
 public class QueryOperationFactory {
 
-    public OperationDefinition create(String operationName, Supplier<SelectionSet> selectionSetSupplier) {
+    public OperationDefinition create(String operationName, SelectionSet selectionSet) {
         return OperationDefinition.newOperationDefinition()
                 .name(operationName)
-                .selectionSet(selectionSetSupplier.get())
+                .selectionSet(selectionSet)
                 .operation(Operation.QUERY)
                 .build();
 

--- a/src/main/java/com/intuit/graphql/orchestrator/xtext/FieldContext.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/xtext/FieldContext.java
@@ -1,5 +1,6 @@
 package com.intuit.graphql.orchestrator.xtext;
 
+import graphql.schema.FieldCoordinates;
 import java.util.Objects;
 import lombok.Getter;
 
@@ -8,10 +9,12 @@ public class FieldContext {
 
   private final String parentType;
   private final String fieldName;
+  private final FieldCoordinates fieldCoordinates;
 
   public FieldContext(String parentType, String fieldName) {
     this.parentType = parentType;
     this.fieldName = fieldName;
+    this.fieldCoordinates = FieldCoordinates.coordinates(parentType, fieldName);
   }
 
   @Override

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/FieldResolverDirectiveTargetIsNestedFieldSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/FieldResolverDirectiveTargetIsNestedFieldSpec.groovy
@@ -8,7 +8,7 @@ import graphql.ExecutionResult
 import helpers.BaseIntegrationTestSpecification
 import spock.lang.Subject
 
-class FieldResolverDirectiveNestedSpec extends BaseIntegrationTestSpecification {
+class FieldResolverDirectiveTargetIsNestedFieldSpec extends BaseIntegrationTestSpecification {
     def PERSON_DOWNSTREAM_QUERY = "query Get_Person {person {id} person {name}}";
     def BOOK_DOWNSTREAM_QUERY = "query Get_Person {person {book {id name author {lastName}}}}";
     def PETS_DOWNSTREAM_QUERY = "query Get_Person {person {pets {name}}}";
@@ -62,7 +62,7 @@ class FieldResolverDirectiveNestedSpec extends BaseIntegrationTestSpecification 
                 .build();
     }
 
-    def "testFieldResolverInNestedField"() {
+    def "FieldResolver target is a nested field"() {
         given:
         specUnderTest = createGraphQLOrchestrator([mockPersonService, mockBookService, mockPetsService]);
 

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/NestedFieldResolverSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/NestedFieldResolverSpec.groovy
@@ -28,16 +28,17 @@ class NestedFieldResolverSpec extends BaseIntegrationTestSpecification {
         }         
     """
 
-    def QUERY_A = "query Resolver_Directive_Query {aTopField_0:aTopField(p1:\"bObjectFieldValue\") {aObjectField}}"
+    def QUERY_A = "query Resolver_Directive_Query {aTopField_0:aTopField(p1:\"bObjectFieldValue1\") {aObjectField} aTopField_1:aTopField(p1:\"bObjectFieldValue2\") {aObjectField cTopField {cObjectField}}}"
     def mockServiceResponseA = [
             (QUERY_A): [data: [
-                    aTopField_0: [ aObjectField: "aObjectFieldValue"]
+                    aTopField_0: [ aObjectField: "aObjectFieldValue1"],
+                    aTopField_1: [ aObjectField: "aObjectFieldValue2"]
             ]]
     ]
 
     def schemaB = """
         type Query {
-            bTopField: BObjectType
+            bTopField: [BObjectType]
         }
         
         type BObjectType {
@@ -57,7 +58,7 @@ class NestedFieldResolverSpec extends BaseIntegrationTestSpecification {
     def QUERY_B = "query QUERY {bTopField {bObjectField}}"
     def mockServiceResponseB = [
             (QUERY_B) : [ data: [
-                    bTopField: [ bObjectField: "bObjectFieldValue"]
+                    bTopField: [[ bObjectField: "bObjectFieldValue1"], [ bObjectField: "bObjectFieldValue2"]]
             ]]
     ]
 
@@ -71,10 +72,11 @@ class NestedFieldResolverSpec extends BaseIntegrationTestSpecification {
         }
     """
 
-    def QUERY_C = "query Resolver_Directive_Query {cTopField_0:cTopField {cObjectField}}"
+    def QUERY_C = "query Resolver_Directive_Query {cTopField_0:cTopField {cObjectField} cTopField_1:cTopField {cObjectField}}"
     def mockServiceResponseC = [
             (QUERY_C): [data: [
-                    cTopField_0: [ cObjectField: "cObjectFieldValue"]
+                    cTopField_0: [ cObjectField: "cObjectFieldValue1"],
+                    cTopField_1: [ cObjectField: "cObjectFieldValue2"],
             ]]
     ]
 
@@ -114,12 +116,18 @@ class NestedFieldResolverSpec extends BaseIntegrationTestSpecification {
         then:
         executionResult.getErrors().isEmpty()
         executionResult?.data?.bTopField?.size() == 2
-        executionResult?.data?.bTopField?.bObjectField == "bObjectFieldValue"
-        executionResult?.data?.bTopField?.aTopField?.size() == 2
-        executionResult?.data?.bTopField?.aTopField?.aObjectField == "aObjectFieldValue"
-        executionResult?.data?.bTopField?.aTopField?.cTopField?.size() == 1
-        executionResult?.data?.bTopField?.aTopField?.cTopField?.cObjectField == "cObjectFieldValue"
-
+        executionResult?.data?.bTopField[0]?.size() == 2
+        executionResult?.data?.bTopField[1]?.size() == 2
+        executionResult?.data?.bTopField[0]?.bObjectField == "bObjectFieldValue1"
+        executionResult?.data?.bTopField[0]?.aTopField?.size() == 2
+        executionResult?.data?.bTopField[0]?.aTopField?.aObjectField == "aObjectFieldValue1"
+        executionResult?.data?.bTopField[0]?.aTopField?.cTopField?.size() == 1
+        executionResult?.data?.bTopField[0]?.aTopField?.cTopField?.cObjectField == "cObjectFieldValue1"
+        executionResult?.data?.bTopField[1]?.bObjectField == "bObjectFieldValue2"
+        executionResult?.data?.bTopField[1]?.aTopField?.size() == 2
+        executionResult?.data?.bTopField[1]?.aTopField?.aObjectField == "aObjectFieldValue2"
+        executionResult?.data?.bTopField[1]?.aTopField?.cTopField?.size() == 1
+        executionResult?.data?.bTopField[1]?.aTopField?.cTopField?.cObjectField == "cObjectFieldValue2"
     }
 
 }

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/NestedFieldResolverSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/NestedFieldResolverSpec.groovy
@@ -1,0 +1,125 @@
+package com.intuit.graphql.orchestrator.integration
+
+import com.intuit.graphql.orchestrator.GraphQLOrchestrator
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.schema.GraphQLSchema
+import helpers.BaseIntegrationTestSpecification
+import spock.lang.Subject
+
+class NestedFieldResolverSpec extends BaseIntegrationTestSpecification {
+
+    def schemaA = """   
+        type Query {
+            aTopField(p1: String!): AObjectType!
+        }
+        
+        type AObjectType {
+            aObjectField: String
+            cTopField: CObjectType @resolver(field: "cTopField")
+        }   
+        
+        type CObjectType
+        
+        directive @resolver(field: String!, arguments: [A_ResolverArgument!]) on FIELD_DEFINITION
+        input A_ResolverArgument { # If this is type, dapi does not throws error
+            name : String!
+            value : String!
+        }         
+    """
+
+    def QUERY_A = "query Resolver_Directive_Query {aTopField_0:aTopField(p1:\"bObjectFieldValue\") {aObjectField}}"
+    def mockServiceResponseA = [
+            (QUERY_A): [data: [
+                    aTopField_0: [ aObjectField: "aObjectFieldValue"]
+            ]]
+    ]
+
+    def schemaB = """
+        type Query {
+            bTopField: BObjectType
+        }
+        
+        type BObjectType {
+            bObjectField: String
+            aTopField: AObjectType @resolver(field: "aTopField", arguments: [{name : "p1", value: "\$bObjectField"}])
+        }
+
+        type AObjectType
+        
+        directive @resolver(field: String!, arguments: [ResolverArgument!]) on FIELD_DEFINITION
+        input ResolverArgument { # If this is type, dapi does not throws error
+            name : String!
+            value : String!
+        }             
+    """
+
+    def QUERY_B = "query QUERY {bTopField {bObjectField}}"
+    def mockServiceResponseB = [
+            (QUERY_B) : [ data: [
+                    bTopField: [ bObjectField: "bObjectFieldValue"]
+            ]]
+    ]
+
+    def schemaC = """
+        type Query {
+            cTopField: CObjectType!
+        }
+
+        type CObjectType {
+            cObjectField: String
+        }
+    """
+
+    def QUERY_C = "query Resolver_Directive_Query {cTopField_0:cTopField {cObjectField}}"
+    def mockServiceResponseC = [
+            (QUERY_C): [data: [
+                    cTopField_0: [ cObjectField: "cObjectFieldValue"]
+            ]]
+    ]
+
+    GraphQLSchema graphQLSchema
+
+    @Subject
+    GraphQLOrchestrator specUnderTest
+
+    void setup() {
+        def serviceA = createQueryMatchingService("ServiceA", schemaA, mockServiceResponseA)
+        def serviceB = createQueryMatchingService("ServiceB", schemaB, mockServiceResponseB)
+        def serviceC = createQueryMatchingService("ServiceC", schemaC, mockServiceResponseC)
+        specUnderTest = createGraphQLOrchestrator([serviceA, serviceB, serviceC])
+        graphQLSchema = specUnderTest.getSchema()
+    }
+
+    def "Nested FieldResolver"() {
+        given:
+        def graphqlQuery =    """
+            {
+                bTopField {
+                    bObjectField
+                    aTopField {
+                        aObjectField  
+                        cTopField {
+                            cObjectField
+                        }                                              
+                    }
+                }
+            }
+        """
+        ExecutionInput executionInput = createExecutionInput(graphqlQuery)
+
+        when:
+        ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
+
+        then:
+        executionResult.getErrors().isEmpty()
+        executionResult?.data?.bTopField?.size() == 2
+        executionResult?.data?.bTopField?.bObjectField == "bObjectFieldValue"
+        executionResult?.data?.bTopField?.aTopField?.size() == 2
+        executionResult?.data?.bTopField?.aTopField?.aObjectField == "aObjectFieldValue"
+        executionResult?.data?.bTopField?.aTopField?.cTopField?.size() == 1
+        executionResult?.data?.bTopField?.aTopField?.cTopField?.cObjectField == "cObjectFieldValue"
+
+    }
+
+}

--- a/src/test/groovy/helpers/BaseIntegrationTestSpecification.groovy
+++ b/src/test/groovy/helpers/BaseIntegrationTestSpecification.groovy
@@ -4,6 +4,7 @@ import com.intuit.graphql.orchestrator.GraphQLOrchestrator
 import com.intuit.graphql.orchestrator.ServiceProvider
 import com.intuit.graphql.orchestrator.schema.RuntimeGraph
 import com.intuit.graphql.orchestrator.stitching.SchemaStitcher
+import com.intuit.graphql.orchestrator.testhelpers.MockServiceProvider
 import com.intuit.graphql.orchestrator.testhelpers.SimpleMockServiceProvider
 import graphql.ExecutionInput
 import graphql.execution.AsyncExecutionStrategy
@@ -20,17 +21,25 @@ class BaseIntegrationTestSpecification extends Specification {
     def testService
 
     def createSimpleMockService(String testSchema, Map<String, Object> mockServiceResponse) {
-        return new SimpleMockServiceProvider().builder()
+        return SimpleMockServiceProvider.builder()
                 .sdlFiles(["schema.graphqls": testSchema])
                 .mockResponse(mockServiceResponse)
                 .build()
     }
 
     def createSimpleMockService(String namespace, String testSchema, Map<String, Object> mockServiceResponse) {
-        return new SimpleMockServiceProvider().builder()
+        return SimpleMockServiceProvider.builder()
                 .sdlFiles(["schema.graphqls": testSchema])
                 .namespace(namespace)
                 .mockResponse(mockServiceResponse)
+                .build()
+    }
+
+    def createQueryMatchingService(String namespace, String testSchema, Map<String, Object> mockServiceResponse) {
+        return MockServiceProvider.builder()
+                .sdlFiles(["schema.graphqls": testSchema])
+                .namespace(namespace)
+                .responseMap(mockServiceResponse)
                 .build()
     }
 

--- a/src/test/java/com/intuit/graphql/orchestrator/testhelpers/JsonTestUtils.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/testhelpers/JsonTestUtils.java
@@ -2,6 +2,7 @@ package com.intuit.graphql.orchestrator.testhelpers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
 
 public class JsonTestUtils {
 
@@ -12,6 +13,14 @@ public class JsonTestUtils {
       return MAPPER.writeValueAsString(map);
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Input map cannot be converted to json", e);
+    }
+  }
+
+  public static Map<String, Object> jsonToMap(String jsonString) {
+    try {
+      return MAPPER.readValue(jsonString, Map.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("json string cannot be converted to Map", e);
     }
   }
 

--- a/src/test/java/com/intuit/graphql/orchestrator/testhelpers/MockServiceProvider.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/testhelpers/MockServiceProvider.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import org.apache.commons.collections4.MapUtils;
 
 public class MockServiceProvider implements ServiceProvider {
 
@@ -52,7 +53,11 @@ public class MockServiceProvider implements ServiceProvider {
   @Override
   public CompletableFuture<Map<String, Object>> query(ExecutionInput executionInput,
       GraphQLContext context) {
-    return CompletableFuture.completedFuture(this.responseMap.get(executionInput.getQuery()));
+    Map<String, Object> data = this.responseMap.get(executionInput.getQuery());
+    if (MapUtils.isEmpty(data)) {
+      throw new IllegalArgumentException("Mock response not found for query: " + executionInput.getQuery());
+    }
+    return CompletableFuture.completedFuture(data);
   }
 
   public static Builder builder() {

--- a/src/test/java/com/intuit/graphql/orchestrator/testhelpers/MockServiceProvider.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/testhelpers/MockServiceProvider.java
@@ -1,26 +1,59 @@
 package com.intuit.graphql.orchestrator.testhelpers;
 
-import static com.intuit.graphql.orchestrator.testhelpers.TestFileLoader.loadJsonAsMap;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
+import static com.intuit.graphql.orchestrator.testhelpers.JsonTestUtils.jsonToMap;
 
-import com.google.common.collect.ImmutableMap;
 import com.intuit.graphql.orchestrator.ServiceProvider;
-import com.intuit.graphql.orchestrator.ServiceProvider.ServiceType;
+import com.intuit.graphql.orchestrator.TestHelper;
 import graphql.ExecutionInput;
 import graphql.GraphQLContext;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import org.mockito.Mockito;
 
-public class MockServiceProvider {
+public class MockServiceProvider implements ServiceProvider {
+
+  private final String namespace;
+  private final Map<String, String> sdlFiles;
+  private final Set<String> domainTypes;
+  private final ServiceType serviceType;
+  private final Map<String, Map<String, Object>> responseMap;
+
+  public MockServiceProvider(Builder builder) {
+    this.namespace = builder.namespace;
+    this.sdlFiles = builder.sdlFiles;
+    this.domainTypes = builder.domainTypes;
+    this.serviceType = builder.serviceType;
+    this.responseMap = builder.responseMap;
+  }
+
+  @Override
+  public String getNameSpace() {
+    return this.namespace;
+  }
+
+  @Override
+  public Set<String> domainTypes() {
+    return this.domainTypes;
+  }
+
+  @Override
+  public Map<String, String> sdlFiles() {
+    return this.sdlFiles;
+  }
+
+  @Override
+  public ServiceType getSeviceType() {
+    return this.serviceType;
+  }
+
+  @Override
+  public CompletableFuture<Map<String, Object>> query(ExecutionInput executionInput,
+      GraphQLContext context) {
+    return CompletableFuture.completedFuture(this.responseMap.get(executionInput.getQuery()));
+  }
 
   public static Builder builder() {
     return new MockServiceProvider.Builder();
@@ -28,55 +61,50 @@ public class MockServiceProvider {
 
   public static final class Builder {
 
-    private ServiceProvider mockServiceProvider = Mockito.mock(ServiceProvider.class);
-    private List<ServiceProviderMockResponse> mockResponses = new ArrayList<>();
+    private String namespace;
+    private Map<String, String> sdlFiles = new HashMap<>();
+    private Set<String> domainTypes = Collections.emptySet();
+    private ServiceType serviceType = ServiceType.GRAPHQL;
+    private Map<String, Map<String, Object>> responseMap = new HashMap<>();
 
     private Builder() {
-      when(mockServiceProvider.domainTypes()).thenReturn(Collections.emptySet());
-      when(mockServiceProvider.getSeviceType()).thenReturn(ServiceType.GRAPHQL);
-      doReturn(CompletableFuture.completedFuture(ImmutableMap.of("data", Collections.emptyMap())))
-          .when(mockServiceProvider)
-          .query(any(ExecutionInput.class), any(GraphQLContext.class));
     }
 
     public Builder namespace(String namespace) {
-      when(mockServiceProvider.getNameSpace()).thenReturn(namespace);
+      this.namespace = namespace;
       return this;
     }
 
     public Builder sdlFiles(Map<String, String> sdlFiles) {
-      when(mockServiceProvider.sdlFiles()).thenReturn(sdlFiles);
+      this.sdlFiles = sdlFiles;
       return this;
     }
 
     public Builder domainTypes(Set<String> domainTypes) {
-      when(mockServiceProvider.domainTypes()).thenReturn(domainTypes);
+      this.domainTypes = domainTypes;
       return this;
     }
 
     public Builder serviceType(ServiceType serviceType) {
-      when(mockServiceProvider.getSeviceType()).thenReturn(serviceType);
+      this.serviceType = serviceType;
+      return this;
+    }
+
+    public Builder responseMap(Map<String, Map<String, Object>> responseMap) {
+      this.responseMap = responseMap;
       return this;
     }
 
     public Builder mockResponse(ServiceProviderMockResponse serviceProviderMockResponse) {
-      mockResponses.add(serviceProviderMockResponse);
+      String jsonString = TestHelper.getResourceAsString(serviceProviderMockResponse.getExpectResponse());
+      this.responseMap.put(serviceProviderMockResponse.getForExecutionInput().getQuery(),
+          jsonToMap(jsonString));
       return this;
     }
 
-    public ServiceProvider build() throws IOException {
-      for (ServiceProviderMockResponse serviceProviderMockResponse : this.mockResponses) {
-
-        Map<String, Object> data = loadJsonAsMap(serviceProviderMockResponse.getExpectResponse());
-
-        ExecutionInput executionInput = serviceProviderMockResponse.getForExecutionInput();
-
-        doReturn(CompletableFuture.completedFuture(data))
-            .when(mockServiceProvider)
-            .query(argThat(new ExecutionInputMatcher(executionInput)), any(GraphQLContext.class));
-      }
-
-      return this.mockServiceProvider;
+    public MockServiceProvider build() throws IOException {
+      return new MockServiceProvider(this);
     }
+
   }
 }


### PR DESCRIPTION
# What Changed

This PR allows @resolver to target fields that has @resolver under its grapqh.  Please refer to `NestedFieldResolverSpec.groovy` for an example usage.