### PR TITLE
use getContext instead of getLocalContext

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/batch/FieldResolverBatchLoader.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/batch/FieldResolverBatchLoader.java
@@ -173,7 +173,7 @@ public class FieldResolverBatchLoader implements BatchLoader<DataFetchingEnviron
         .operationName(resolverQueryOpDef.getName())
         .build();
 
-    return serviceProvider.query(resolverQueryExecutionInput, dataFetchingEnvironment.getLocalContext());
+    return serviceProvider.query(resolverQueryExecutionInput, dataFetchingEnvironment.getContext());
   }
 
 }


### PR DESCRIPTION
# What Changed
Using DataFetchingEnvironment.getContext() instead of DataFetchingEnvironment.getLocalContext().  

# Why
getLocalContext() does not return the context