### PR TITLE
Fix fieldresolver graphqlctx

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/resolverdirective/FieldResolverDirectiveUtil.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/resolverdirective/FieldResolverDirectiveUtil.java
@@ -28,6 +28,9 @@ public class FieldResolverDirectiveUtil {
   public static final String RESOLVER_DIRECTIVE_NAME = "resolver";
   public static final String FIELD_REFERENCE_PREFIX = "$";
 
+  public static final String FQN_KEYWORD_QUERY = "query";
+  public static final char FQN_FIELD_SEPARATOR = '.';
+
   public static final CharSequence OPERATION_NAME_SEPARATOR = "_";
   public static final CharSequence RESOLVER_DIRECTIVE_QUERY_NAME = "Resolver_Directive_Query";
 

--- a/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMerge.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMerge.java
@@ -1,5 +1,7 @@
 package com.intuit.graphql.orchestrator.schema.transform;
 
+import static com.intuit.graphql.orchestrator.resolverdirective.FieldResolverDirectiveUtil.FQN_FIELD_SEPARATOR;
+import static com.intuit.graphql.orchestrator.resolverdirective.FieldResolverDirectiveUtil.FQN_KEYWORD_QUERY;
 import static com.intuit.graphql.orchestrator.utils.XtextGraphUtils.addToCodeRegistry;
 import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.createNamedType;
 import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.getFieldDefinitions;
@@ -198,9 +200,9 @@ public class FieldResolverTransformerPostMerge implements Transformer<XtextGraph
 
   private FieldDefinition getFieldDefinitionByFQN(final String queryFieldFQN, XtextGraph xtextGraph) {
 
-    String queryFieldFQNNoQuery = StringUtils.removeStart(queryFieldFQN ,"query."); // remove if exists
+    String queryFieldFQNNoQuery = StringUtils.removeStart(queryFieldFQN ,FQN_KEYWORD_QUERY + FQN_FIELD_SEPARATOR); // remove if exists
 
-    String[] queryFieldFQNTokens = StringUtils.split(queryFieldFQNNoQuery, '.');
+    String[] queryFieldFQNTokens = StringUtils.split(queryFieldFQNNoQuery, FQN_FIELD_SEPARATOR);
     if (ArrayUtils.isEmpty(queryFieldFQNTokens)) {
       String errorMessage = String.format("Failed to tokenize queryFieldFQN.  queryFieldFQN=%s", queryFieldFQN);
       throw new IllegalArgumentException(errorMessage);

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/NestedFieldResolverSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/NestedFieldResolverSpec.groovy
@@ -11,6 +11,10 @@ class NestedFieldResolverSpec extends BaseIntegrationTestSpecification {
 
     def schemaA = """   
         type Query {
+            arootField: ARootType
+        }
+
+        type ARootType {
             aTopField(p1: String!): AObjectType!
         }
         
@@ -28,11 +32,13 @@ class NestedFieldResolverSpec extends BaseIntegrationTestSpecification {
         }         
     """
 
-    def QUERY_A = "query Resolver_Directive_Query {aTopField_0:aTopField(p1:\"bObjectFieldValue1\") {aObjectField} aTopField_1:aTopField(p1:\"bObjectFieldValue2\") {aObjectField cTopField {cObjectField}}}"
+    def QUERY_A = "query Resolver_Directive_Query {arootField {aTopField_0:aTopField(p1:\"bObjectFieldValue1\") {aObjectField}} arootField {aTopField_1:aTopField(p1:\"bObjectFieldValue2\") {aObjectField cTopField {cObjectField}}}}"
     def mockServiceResponseA = [
             (QUERY_A): [data: [
-                    aTopField_0: [ aObjectField: "aObjectFieldValue1"],
-                    aTopField_1: [ aObjectField: "aObjectFieldValue2"]
+                    arootField : [
+                            aTopField_0: [ aObjectField: "aObjectFieldValue1"],
+                            aTopField_1: [ aObjectField: "aObjectFieldValue2"]
+                    ]
             ]]
     ]
 
@@ -43,7 +49,7 @@ class NestedFieldResolverSpec extends BaseIntegrationTestSpecification {
         
         type BObjectType {
             bObjectField: String
-            aTopField: AObjectType @resolver(field: "aTopField", arguments: [{name : "p1", value: "\$bObjectField"}])
+            aTopField: AObjectType @resolver(field: "arootField.aTopField", arguments: [{name : "p1", value: "\$bObjectField"}])
         }
 
         type AObjectType


### PR DESCRIPTION
# What Changed
- using field resolver FQN, start from the root field to search for the ServiceDataFetcher.  
- minor refactor

# Why
- For nested fields, they might be a case that FieldResolver target field is an AliasablePropertyDataFetcher and ServiceDataFetcher is assigned to one of its ancestors.
Todo:
