### PR TITLE
optimize service metadata implementation

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/federation/metadata/FederationMetadata.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/federation/metadata/FederationMetadata.java
@@ -5,7 +5,6 @@ import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.getFieldDefin
 import com.intuit.graphql.graphQL.FieldDefinition;
 import com.intuit.graphql.graphQL.TypeDefinition;
 import com.intuit.graphql.orchestrator.ServiceProvider;
-import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
 import graphql.language.Field;
 import graphql.schema.FieldCoordinates;
 import java.util.HashMap;
@@ -25,19 +24,23 @@ import lombok.NonNull;
 @Getter
 public class FederationMetadata {
 
-  private final ServiceMetadata serviceMetadata;
+  private final ServiceProvider serviceProvider;
 
-  /** entities owned by the service */
+  /**
+   * entities owned by the service
+   */
   private final Map<String, EntityMetadata> entitiesByTypename = new HashMap<>();
 
-  /** entities extended by the service */
+  /**
+   * entities extended by the service
+   */
   private final Map<String, EntityExtensionMetadata> extensionsByTypename = new HashMap<>();
 
   private final Map<FieldCoordinates, Set<Field>> requiresFieldSetByCoordinate = new HashMap<>();
 
-  public FederationMetadata(ServiceMetadata serviceMetadata) {
-    Objects.requireNonNull(serviceMetadata);
-    this.serviceMetadata = serviceMetadata;
+  public FederationMetadata(ServiceProvider serviceProvider) {
+    Objects.requireNonNull(serviceProvider);
+    this.serviceProvider = serviceProvider;
   }
 
   public boolean isFieldExternal(FieldCoordinates fieldCoordinates) {
@@ -72,10 +75,15 @@ public class FederationMetadata {
   @Builder
   @Getter
   public static class EntityMetadata {
-    @NonNull private final String typeName;
-    @NonNull private final List<KeyDirectiveMetadata> keyDirectives;
-    @NonNull private final Set<String> fields;
-    @NonNull private final FederationMetadata federationMetadata;
+
+    @NonNull
+    private final String typeName;
+    @NonNull
+    private final List<KeyDirectiveMetadata> keyDirectives;
+    @NonNull
+    private final Set<String> fields;
+    @NonNull
+    private final FederationMetadata federationMetadata;
 
     public static Set<String> getFieldsFrom(TypeDefinition entityDefinition) {
       Set<String> output = new HashSet<>(); // make sure HashSet is used
@@ -89,10 +97,15 @@ public class FederationMetadata {
   @Builder
   @Getter
   public static class EntityExtensionMetadata {
-    @NonNull private final String typeName;
-    @NonNull private final List<KeyDirectiveMetadata> keyDirectives;
-    @NonNull private final Map<String, Set<Field>> requiredFieldsByFieldName;
-    @NonNull private final FederationMetadata federationMetadata;
+
+    @NonNull
+    private final String typeName;
+    @NonNull
+    private final List<KeyDirectiveMetadata> keyDirectives;
+    @NonNull
+    private final Map<String, Set<Field>> requiredFieldsByFieldName;
+    @NonNull
+    private final FederationMetadata federationMetadata;
     // TODO @provides
 
     private EntityMetadata baseEntityMetadata;
@@ -112,13 +125,12 @@ public class FederationMetadata {
     }
 
     public ServiceProvider getServiceProvider() {
-      return this.federationMetadata.getServiceMetadata().getServiceProvider();
+      return this.federationMetadata.getServiceProvider();
     }
 
     public ServiceProvider getBaseServiceProvider() {
       return this.baseEntityMetadata
           .getFederationMetadata()
-          .getServiceMetadata()
           .getServiceProvider();
     }
 

--- a/src/main/java/com/intuit/graphql/orchestrator/schema/ServiceMetadataImpl.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/schema/ServiceMetadataImpl.java
@@ -1,0 +1,140 @@
+package com.intuit.graphql.orchestrator.schema;
+
+import static java.util.Objects.requireNonNull;
+
+import com.intuit.graphql.orchestrator.ServiceProvider;
+import com.intuit.graphql.orchestrator.federation.metadata.FederationMetadata;
+import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext;
+import graphql.schema.FieldCoordinates;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Getter;
+
+@Getter
+public class ServiceMetadataImpl implements ServiceMetadata {
+
+  private final Map<String, TypeMetadata> typeMetadataMap;
+  private final ServiceProvider serviceProvider;
+  private final FederationMetadata federationMetadata;
+  private final boolean hasInterfaceOrUnion;
+  private final boolean hasFieldResolverDefinition;
+
+  private ServiceMetadataImpl(Builder builder) {
+    typeMetadataMap = builder.typeMetadataMap;
+    serviceProvider = requireNonNull(builder.serviceProvider);
+    federationMetadata = builder.federationMetadata;
+    hasInterfaceOrUnion = builder.hasInterfaceOrUnion;
+    hasFieldResolverDefinition = builder.hasFieldResolverDefinition;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static Builder newBuilder(ServiceMetadataImpl copy) {
+    Builder builder = new Builder();
+    builder.typeMetadataMap = copy.getTypeMetadataMap();
+    builder.serviceProvider = copy.getServiceProvider();
+    builder.federationMetadata = copy.getFederationMetadata();
+    builder.hasInterfaceOrUnion = copy.isHasInterfaceOrUnion();
+    builder.hasFieldResolverDefinition = copy.isHasFieldResolverDefinition();
+    return builder;
+  }
+
+  @Override
+  public boolean hasType(String typeName) {
+    return this.typeMetadataMap.containsKey(typeName);
+  }
+
+  @Override
+  public boolean requiresTypenameInjection() {
+    return this.hasInterfaceOrUnion;
+  }
+
+  @Override
+  public boolean hasFieldResolverDirective() {
+    return this.hasFieldResolverDefinition;
+  }
+
+  @Override
+  public boolean isFederationService() {
+    return this.serviceProvider.isFederationProvider();
+  }
+
+  @Override
+  public boolean shouldRemoveExternalFields() {
+    return this.hasFieldResolverDirective() || this.isFederationService();
+  }
+
+
+  @Override
+  public ServiceProvider getServiceProvider() {
+    return this.serviceProvider;
+  }
+
+  @Override
+  public FieldResolverContext getFieldResolverContext(FieldCoordinates fieldCoordinates) {
+    return Optional.ofNullable(this.typeMetadataMap.get(fieldCoordinates.getTypeName()))
+        .map(typeMetadata -> typeMetadata.getFieldResolverContext(fieldCoordinates.getFieldName()))
+        .orElse(null);
+  }
+
+  @Override
+  public boolean isOwnedByEntityExtension(FieldCoordinates fieldCoordinates) {
+    return this.serviceProvider.isFederationProvider() && federationMetadata.isFieldExternal(fieldCoordinates);
+  }
+
+
+  @Override
+  public boolean isEntity(String typename) {
+    return this.isFederationService() && this.federationMetadata.isEntity(typename);
+  }
+
+  @Override
+  public FederationMetadata getFederationServiceMetadata() {
+    return federationMetadata;
+  }
+
+
+  public static final class Builder {
+
+    private Map<String, TypeMetadata> typeMetadataMap = new HashMap<>();
+    private ServiceProvider serviceProvider;
+    private FederationMetadata federationMetadata;
+    private boolean hasInterfaceOrUnion;
+    private boolean hasFieldResolverDefinition;
+
+    private Builder() {
+    }
+
+    public Builder typeMetadataMap(Map<String, TypeMetadata> val) {
+      typeMetadataMap = val;
+      return this;
+    }
+
+    public Builder serviceProvider(ServiceProvider val) {
+      serviceProvider = val;
+      return this;
+    }
+
+    public Builder federationMetadata(FederationMetadata val) {
+      federationMetadata = val;
+      return this;
+    }
+
+    public Builder hasInterfaceOrUnion(boolean val) {
+      hasInterfaceOrUnion = val;
+      return this;
+    }
+
+    public Builder hasFieldResolverDefinition(boolean val) {
+      hasFieldResolverDefinition = val;
+      return this;
+    }
+
+    public ServiceMetadataImpl build() {
+      return new ServiceMetadataImpl(this);
+    }
+  }
+}

--- a/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FederationTransformerPreMerge.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FederationTransformerPreMerge.java
@@ -38,7 +38,7 @@ public class FederationTransformerPreMerge implements Transformer<XtextGraph, Xt
     @Override
     public XtextGraph transform(XtextGraph source) {
         if(source.getServiceProvider().isFederationProvider()) {
-            FederationMetadata federationMetadata = new FederationMetadata(source);
+            FederationMetadata federationMetadata = new FederationMetadata(source.getServiceProvider());
 
             source.getEntitiesByTypeName().values()
             .forEach(typeDefinition -> {

--- a/src/main/java/com/intuit/graphql/orchestrator/stitching/XtextStitcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/stitching/XtextStitcher.java
@@ -23,15 +23,17 @@ import com.intuit.graphql.orchestrator.resolverdirective.ResolverArgumentDirecti
 import com.intuit.graphql.orchestrator.resolverdirective.ResolverArgumentQueryBuilder;
 import com.intuit.graphql.orchestrator.schema.Operation;
 import com.intuit.graphql.orchestrator.schema.RuntimeGraph;
+import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
+import com.intuit.graphql.orchestrator.schema.ServiceMetadataImpl;
 import com.intuit.graphql.orchestrator.schema.fold.XtextGraphFolder;
 import com.intuit.graphql.orchestrator.schema.transform.AllTypesTransformer;
 import com.intuit.graphql.orchestrator.schema.transform.DirectivesTransformer;
 import com.intuit.graphql.orchestrator.schema.transform.DomainTypesTransformer;
+import com.intuit.graphql.orchestrator.schema.transform.FederationTransformerPostMerge;
 import com.intuit.graphql.orchestrator.schema.transform.FederationTransformerPreMerge;
 import com.intuit.graphql.orchestrator.schema.transform.FieldResolverTransformerPostMerge;
 import com.intuit.graphql.orchestrator.schema.transform.FieldResolverTransformerPreMerge;
 import com.intuit.graphql.orchestrator.schema.transform.GraphQLAdapterTransformer;
-import com.intuit.graphql.orchestrator.schema.transform.FederationTransformerPostMerge;
 import com.intuit.graphql.orchestrator.schema.transform.ResolverArgumentTransformer;
 import com.intuit.graphql.orchestrator.schema.transform.Transformer;
 import com.intuit.graphql.orchestrator.schema.transform.TypeExtensionTransformer;
@@ -105,24 +107,30 @@ public class XtextStitcher implements Stitcher {
     //Stitch Graphs
     XtextGraph stitchedGraph = new XtextGraphFolder().fold(XtextGraph.emptyGraph(), xtextGraphMap.values());
 
+    //Service Metadata
+    final Map<String, ServiceMetadata> serviceMetadataMap = xtextGraphMap.values().parallelStream()
+        .map(this::buildServiceMetadata)
+        .collect(Collectors.toMap(metadata -> metadata.getServiceProvider().getNameSpace(), Function.identity()));
+
     //Transform after merge
     XtextGraph stitchedTransformedGraph = transform(stitchedGraph, postMergeTransformers);
 
     //Executable RuntimeGraph with BatchLoaders and DataFetchers
-    final Map<String, BatchLoader> batchLoaders = getBatchLoaders(xtextGraphMap);
+    final Map<String, BatchLoader> batchLoaders = getBatchLoaders(serviceMetadataMap);
 
     stitchedTransformedGraph.getFieldResolverContexts().forEach(fieldResolverContext -> {
       FieldResolverBatchLoader fieldResolverDataLoader = FieldResolverBatchLoader
-              .builder()
-              .fieldResolverContext(fieldResolverContext)
-              .build();
+          .builder()
+          .fieldResolverContext(fieldResolverContext)
+          .build();
 
       String batchLoaderKey = FieldResolverDataLoaderUtil.createDataLoaderKeyFrom(fieldResolverContext);
       batchLoaders.put(batchLoaderKey, fieldResolverDataLoader);
 
     });
 
-    final GraphQLCodeRegistry.Builder codeRegistryBuilder = getCodeRegistry(stitchedTransformedGraph, xtextGraphMap);
+    final GraphQLCodeRegistry.Builder codeRegistryBuilder = getCodeRegistry(stitchedTransformedGraph,
+        serviceMetadataMap);
 
     final RuntimeGraph.Builder runtimeGraphBuilder = createRuntimeGraph(stitchedTransformedGraph);
 
@@ -139,19 +147,21 @@ public class XtextStitcher implements Stitcher {
   /**
    * Creates a namespace vs batch loader map for corresponding data providers per graph
    *
-   * @param xtextGraphMap map of namespace vs xtext graph for all data providers
+   * @param serviceMetadataMap map of namespace vs xtext graph for all data providers
    * @return map of namespace vs batch loader
    */
-  private Map<String, BatchLoader> getBatchLoaders(Map<String, XtextGraph> xtextGraphMap) {
+  private Map<String, BatchLoader> getBatchLoaders(Map<String, ServiceMetadata> serviceMetadataMap) {
 
     HashMap<String, BatchLoader> batchLoaderMap = new HashMap<>();
-    xtextGraphMap.forEach((namespace, graph) -> {
-      if (graph.getServiceProvider().getSeviceType() == ServiceType.GRAPHQL || graph.getServiceProvider().isFederationProvider()) {
+    serviceMetadataMap.forEach((namespace, serviceMetadata) -> {
+      if (serviceMetadata.getServiceProvider().getSeviceType() == ServiceType.GRAPHQL || serviceMetadata
+          .getServiceProvider()
+          .isFederationProvider()) {
         batchLoaderMap.put(namespace,
             GraphQLServiceBatchLoader
                 .newQueryExecutorBatchLoader()
-                .queryExecutor(graph.getServiceProvider())
-                .serviceMetadata(graph)
+                .queryExecutor(serviceMetadata.getServiceProvider())
+                .serviceMetadata(serviceMetadata)
                 .batchLoaderExecutionHooks(batchLoaderHooks)
                 .build());
       }
@@ -159,15 +169,25 @@ public class XtextStitcher implements Stitcher {
     return batchLoaderMap;
   }
 
+  private ServiceMetadata buildServiceMetadata(XtextGraph xtextGraph) {
+    return ServiceMetadataImpl.newBuilder()
+        .serviceProvider(xtextGraph.getServiceProvider())
+        .typeMetadataMap(xtextGraph.getTypeMetadatas())
+        .federationMetadata(xtextGraph.getFederationServiceMetadata())
+        .hasFieldResolverDefinition(xtextGraph.isHasFieldResolverDefinition())
+        .hasInterfaceOrUnion(xtextGraph.isHasInterfaceOrUnion())
+        .build();
+  }
+
   /**
    * Builds GraphQL Code Registry for a xtext graph using field context and data fetcher context
    *
    * @param mergedGraph the post-merged and post-transformed graph
-   * @param graphsByNamespace the individual graphs that were used to build the merged graph
+   * @param serviceMetadataMap the individual graphs that were used to build the merged graph
    * @return GraphQL Code Registry Builder
    */
   private GraphQLCodeRegistry.Builder getCodeRegistry(XtextGraph mergedGraph,
-      Map<String, XtextGraph> graphsByNamespace) {
+      Map<String, ServiceMetadata> serviceMetadataMap) {
 
     GraphQLCodeRegistry.Builder builder = GraphQLCodeRegistry.newCodeRegistry();
 
@@ -178,7 +198,8 @@ public class XtextStitcher implements Stitcher {
       if (type == STATIC) {
         builder.dataFetcher(coordinates, new StaticDataFetcher(Collections.emptyMap()));
       } else if (type == SERVICE) {
-        final XtextGraph serviceMetadata = graphsByNamespace.get(dataFetcherContext.getNamespace());
+        final ServiceMetadata serviceMetadata = serviceMetadataMap.get(dataFetcherContext.getNamespace());
+
         builder.dataFetcher(coordinates,
             dataFetcherContext.getServiceType() == ServiceType.REST
                 ? new RestDataFetcher(serviceMetadata)

--- a/src/main/java/com/intuit/graphql/orchestrator/xtext/XtextGraph.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/xtext/XtextGraph.java
@@ -12,11 +12,9 @@ import com.intuit.graphql.orchestrator.ServiceProvider;
 import com.intuit.graphql.orchestrator.federation.metadata.FederationMetadata;
 import com.intuit.graphql.orchestrator.federation.metadata.FederationMetadata.EntityExtensionMetadata;
 import com.intuit.graphql.orchestrator.schema.Operation;
-import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
 import com.intuit.graphql.orchestrator.schema.TypeMetadata;
 import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext;
 import com.intuit.graphql.utils.XtextTypeUtils;
-import graphql.schema.FieldCoordinates;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -24,7 +22,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import lombok.Getter;
@@ -35,7 +32,7 @@ import org.eclipse.xtext.resource.XtextResourceSet;
  * batchloaders for optimization.
  */
 @Getter
-public class XtextGraph implements ServiceMetadata {
+public class XtextGraph {
 
   private final ServiceProvider serviceProvider;
   private final XtextResourceSet xtextResourceSet;
@@ -71,10 +68,7 @@ public class XtextGraph implements ServiceMetadata {
     //TODO: Research on all Providers having an XtextResource instead of a ResourceSet
     operationMap = builder.operationMap;
     codeRegistry = builder.codeRegistry;
-    for (DirectiveDefinition directiveDefinition : directives = builder.directives) {
-
-    }
-
+    directives = builder.directives;
     types = builder.types;
     typeMetadatas = builder.typeMetadatas;
     hasInterfaceOrUnion = builder.hasInterfaceOrUnion;
@@ -125,9 +119,9 @@ public class XtextGraph implements ServiceMetadata {
   }
 
   /**
-   * Empty runtime graph.
+   * Empty Xtext graph.
    *
-   * @return the runtime graph
+   * @return the Xtext graph
    */
   public static XtextGraph emptyGraph() {
 
@@ -148,64 +142,14 @@ public class XtextGraph implements ServiceMetadata {
    *
    * @return true or false
    */
-  @Override
   public boolean requiresTypenameInjection() {
     return isHasInterfaceOrUnion();
-  }
-
-  @Override
-  public boolean hasFieldResolverDirective() {
-    return hasFieldResolverDefinition;
-  }
-
-  @Override
-  public FieldResolverContext getFieldResolverContext(FieldCoordinates fieldCoordinates) {
-    TypeMetadata typeMetadata = this.typeMetadatas.get(fieldCoordinates.getTypeName());
-    if (Objects.isNull(typeMetadata)) {
-      return null;
-    }
-    return typeMetadata.getFieldResolverContext(fieldCoordinates.getFieldName());
-  }
-
-  @Override
-  public boolean isOwnedByEntityExtension(FieldCoordinates fieldCoordinates) {
-    if (!this.serviceProvider.isFederationProvider()) {
-      return false;
-    }
-
-    FederationMetadata federationMetadata = this.federationMetadataByNamespace.get(serviceProvider.getNameSpace());
-    return federationMetadata.isFieldExternal(fieldCoordinates);
-  }
-
-  @Override
-  public boolean isFederationService() {
-    return this.serviceProvider.isFederationProvider();
-  }
-
-  @Override
-  public boolean isEntity(String typename) {
-    return isFederationService() && getFederationServiceMetadata().isEntity(typename);
   }
 
   public FederationMetadata getFederationServiceMetadata() {
     return getFederationMetadataByNamespace().get(serviceProvider.getNameSpace());
   }
 
-  /**
-   * Check if the given typeName exists in provider's schema.
-   *
-   * @param typeName typeName to check
-   * @return true or false
-   */
-  @Override
-  public boolean hasType(String typeName) {
-    return types.containsKey(typeName);
-  }
-
-  @Override
-  public boolean shouldRemoveExternalFields() {
-    return hasFieldResolverDirective() || isFederationService();
-  }
 
   public TypeDefinition getType(final NamedType namedType) {
     return types.get(XtextTypeUtils.typeName(namedType));
@@ -295,6 +239,7 @@ public class XtextGraph implements ServiceMetadata {
   public void addToEntityExtensionMetadatas(EntityExtensionMetadata entityExtensionMetadatas) {
     this.entityExtensionMetadatas.add(entityExtensionMetadatas);
   }
+
 
   /**
    * The type Builder.
@@ -474,7 +419,8 @@ public class XtextGraph implements ServiceMetadata {
       return this;
     }
 
-    public Builder entityExtensionsByNamespace(Map<String, Map<String, TypeSystemDefinition>> entityExtensionsByNamespace) {
+    public Builder entityExtensionsByNamespace(
+        Map<String, Map<String, TypeSystemDefinition>> entityExtensionsByNamespace) {
       requireNonNull(entityExtensionsByNamespace);
       this.entityExtensionsByNamespace.putAll(entityExtensionsByNamespace);
       return this;

--- a/src/test/groovy/helpers/SchemaTestUtil.groovy
+++ b/src/test/groovy/helpers/SchemaTestUtil.groovy
@@ -11,7 +11,7 @@ class SchemaTestUtil extends Specification {
 
     static RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build()
 
-    static defaultOptions = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+    static defaultOptions = SchemaGenerator.Options.defaultOptions()
 
     static SchemaParser schemaParser = new SchemaParser()
 

--- a/src/test/java/com/intuit/graphql/orchestrator/batch/GraphQLServiceBatchLoaderTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/batch/GraphQLServiceBatchLoaderTest.java
@@ -27,7 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.intuit.graphql.orchestrator.ServiceProvider;
 import com.intuit.graphql.orchestrator.authorization.BatchFieldAuthorization;
 import com.intuit.graphql.orchestrator.batch.GraphQLTestUtil.PassthroughQueryModifier;
-import com.intuit.graphql.orchestrator.xtext.XtextGraph;
+import com.intuit.graphql.orchestrator.schema.ServiceMetadataImpl;
 import graphql.GraphQLContext;
 import graphql.Scalars;
 import graphql.execution.ExecutionStepInfo;
@@ -75,7 +75,7 @@ public class GraphQLServiceBatchLoaderTest {
   public ServiceProvider mockServiceProvider;
 
   @Mock
-  public XtextGraph mockServiceMetadata;
+  public ServiceMetadataImpl mockServiceMetadata;
 
   @Mock
   public VariableDefinitionFilter mockVariableDefinitionFilter;
@@ -506,7 +506,7 @@ public class GraphQLServiceBatchLoaderTest {
     final MergedField mergedFieldWithArgument = newMergedField(
         newField("fieldWithArgument").arguments(
             singletonList(Argument.newArgument("SomeArgument",
-                    newVariableReference().name("TestVariableDefinition").build())
+                newVariableReference().name("TestVariableDefinition").build())
                 .build())).build()).build();
 
     final ExecutionStepInfo root = ExecutionStepInfo.newExecutionStepInfo()
@@ -778,7 +778,6 @@ public class GraphQLServiceBatchLoaderTest {
         .selection(FragmentSpread.newFragmentSpread("firstFrag").build())
         .selection(FragmentSpread.newFragmentSpread("secondFrag").build()).build()).build()).build();
 
-
     GraphQLSchema graphQLSchema = newSchema()
         .query(queryType).build();
 
@@ -803,7 +802,6 @@ public class GraphQLServiceBatchLoaderTest {
     Map<String, FragmentDefinition> m = new HashMap();
     m.put("firstFrag", fdb1);
     m.put("secondFrag", fdb2);
-
 
     DataFetchingEnvironment dfe1 = newDataFetchingEnvironment()
         .variables(ImmutableMap.of("1", "3"))

--- a/src/test/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcherTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcherTest.java
@@ -10,7 +10,7 @@ import com.intuit.graphql.orchestrator.ServiceProvider.ServiceType;
 import com.intuit.graphql.orchestrator.TestServiceProvider;
 import com.intuit.graphql.orchestrator.batch.QueryExecutor;
 import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
-import com.intuit.graphql.orchestrator.xtext.XtextGraph;
+import com.intuit.graphql.orchestrator.schema.ServiceMetadataImpl;
 import graphql.GraphQLContext;
 import graphql.execution.DataFetcherResult;
 import graphql.execution.MergedField;
@@ -85,7 +85,7 @@ public class RestDataFetcherTest {
 
     TestServiceProvider testServiceProvider = TestServiceProvider.newBuilder().queryFunction(queryExecutor)
         .serviceType(ServiceType.REST).build();
-    ServiceMetadata serviceMetadata = mock(XtextGraph.class);
+    ServiceMetadata serviceMetadata = mock(ServiceMetadataImpl.class);
     when(serviceMetadata.getServiceProvider()).thenReturn(testServiceProvider);
 
     RestDataFetcher restDataFetcher = new RestDataFetcher(serviceMetadata);

--- a/src/test/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMergeTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPostMergeTest.java
@@ -84,7 +84,7 @@ public class FieldResolverTransformerPostMergeTest {
             + "} "
             + "directive @resolver(field: String) on ARGUMENT_DEFINITION";
     XtextGraph xtextGraph = createTestXtextGraph(schema);
-    assertThat(xtextGraph.hasFieldResolverDirective()).isFalse();
+    assertThat(xtextGraph.isHasFieldResolverDefinition()).isFalse();
 
     XtextGraph textGraphSpy = Mockito.spy(xtextGraph);
 

--- a/src/test/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPreMergeTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/schema/transform/FieldResolverTransformerPreMergeTest.java
@@ -36,27 +36,27 @@ public class FieldResolverTransformerPreMergeTest {
             + "} "
             + "directive @resolver(field: String) on ARGUMENT_DEFINITION";
     XtextGraph xtextGraph = createTestXtextGraph(schema);
-    assertThat(xtextGraph.hasFieldResolverDirective()).isFalse();
+    assertThat(xtextGraph.isHasFieldResolverDefinition()).isFalse();
 
     // WHEN
     final XtextGraph transformedSource = transformer.transform(xtextGraph);
 
     // THEN
     assertThat(transformedSource.getCodeRegistry().size()).isEqualTo(0);
-    assertThat(transformedSource.hasFieldResolverDirective()).isFalse();
+    assertThat(transformedSource.isHasFieldResolverDefinition()).isFalse();
   }
 
   @Test
   public void transformWithFieldResolverSuccess() {
     // GIVEN
     XtextGraph xtextGraph = createTestXtextGraph(SCHEMA_A_IS_OBJECT_TYPE);
-    assertThat(xtextGraph.hasFieldResolverDirective()).isFalse();
+    assertThat(xtextGraph.isHasFieldResolverDefinition()).isFalse();
 
     // WHEN
     final XtextGraph transformedSource = transformer.transform(xtextGraph);
 
     // THEN
-    assertThat(transformedSource.hasFieldResolverDirective()).isTrue();
+    assertThat(transformedSource.isHasFieldResolverDefinition()).isTrue();
     assertThat(transformedSource.getFieldResolverContexts().size()).isEqualTo(1);
 
     FieldResolverContext actualFieldResolverContext = transformedSource.getFieldResolverContexts().get(0);
@@ -68,13 +68,13 @@ public class FieldResolverTransformerPreMergeTest {
   public void transformWithFieldResolverParentNotNullSuccess() {
     // GIVEN
     XtextGraph xtextGraph = createTestXtextGraph(SCHEMA_A_TYPE_IS_NOT_NULL);
-    assertThat(xtextGraph.hasFieldResolverDirective()).isFalse();
+    assertThat(xtextGraph.isHasFieldResolverDefinition()).isFalse();
 
     // WHEN
     final XtextGraph transformedSource = transformer.transform(xtextGraph);
 
     // THEN
-    assertThat(transformedSource.hasFieldResolverDirective()).isTrue();
+    assertThat(transformedSource.isHasFieldResolverDefinition()).isTrue();
     assertThat(transformedSource.getFieldResolverContexts().size()).isEqualTo(1);
 
     FieldResolverContext actualFieldResolverContext = transformedSource.getFieldResolverContexts().get(0);
@@ -86,13 +86,13 @@ public class FieldResolverTransformerPreMergeTest {
   public void transformWithFieldResolverParentWrappedInArraySuccess() {
     // GIVEN
     XtextGraph xtextGraph = createTestXtextGraph(SCHEMA_A_TYPE_WRAPPED_IN_ARRAY);
-    assertThat(xtextGraph.hasFieldResolverDirective()).isFalse();
+    assertThat(xtextGraph.isHasFieldResolverDefinition()).isFalse();
 
     // WHEN
     final XtextGraph transformedSource = transformer.transform(xtextGraph);
 
     // THEN
-    assertThat(transformedSource.hasFieldResolverDirective()).isTrue();
+    assertThat(transformedSource.isHasFieldResolverDefinition()).isTrue();
     assertThat(transformedSource.getFieldResolverContexts().size()).isEqualTo(1);
 
     FieldResolverContext actualFieldResolverContext = transformedSource.getFieldResolverContexts().get(0);
@@ -104,13 +104,13 @@ public class FieldResolverTransformerPreMergeTest {
   public void transformWithFieldResolverParentNotNullWrappedInArraySuccess() {
     // GIVEN
     XtextGraph xtextGraph = createTestXtextGraph(SCHEMA_A_NOT_NULL_WRAPPED_IN_ARRAY);
-    assertThat(xtextGraph.hasFieldResolverDirective()).isFalse();
+    assertThat(xtextGraph.isHasFieldResolverDefinition()).isFalse();
 
     // WHEN
     final XtextGraph transformedSource = transformer.transform(xtextGraph);
 
     // THEN
-    assertThat(transformedSource.hasFieldResolverDirective()).isTrue();
+    assertThat(transformedSource.isHasFieldResolverDefinition()).isTrue();
     assertThat(transformedSource.getFieldResolverContexts().size()).isEqualTo(1);
 
     FieldResolverContext actualFieldResolverContext = transformedSource.getFieldResolverContexts().get(0);
@@ -121,26 +121,26 @@ public class FieldResolverTransformerPreMergeTest {
   @Test
   public void transformWithTwoFieldResolversYieldsTwoFieldResolverContext() {
     XtextGraph xtextGraph = createTestXtextGraph(SCHEMA_A_WITH_TWO__FIELD_RESOLVERS);
-    assertThat(xtextGraph.hasFieldResolverDirective()).isFalse();
+    assertThat(xtextGraph.isHasFieldResolverDefinition()).isFalse();
 
     // WHEN
     final XtextGraph transformedSource = transformer.transform(xtextGraph);
 
     // THEN
-    assertThat(transformedSource.hasFieldResolverDirective()).isTrue();
+    assertThat(transformedSource.isHasFieldResolverDefinition()).isTrue();
     assertThat(transformedSource.getFieldResolverContexts().size()).isEqualTo(2);
   }
 
   @Test
   public void transformTwoTypesWithFieldWithResolverYieldsTwoFieldResolverContexts() {
     XtextGraph xtextGraph = createTestXtextGraph(SCHEMA_A_AND_C_WITH_WITH_FIELD_RESOLVER);
-    assertThat(xtextGraph.hasFieldResolverDirective()).isFalse();
+    assertThat(xtextGraph.isHasFieldResolverDefinition()).isFalse();
 
     // WHEN
     final XtextGraph transformedSource = transformer.transform(xtextGraph);
 
     // THEN
-    assertThat(transformedSource.hasFieldResolverDirective()).isTrue();
+    assertThat(transformedSource.isHasFieldResolverDefinition()).isTrue();
     assertThat(transformedSource.getFieldResolverContexts().size()).isEqualTo(2);
   }
 
@@ -148,7 +148,7 @@ public class FieldResolverTransformerPreMergeTest {
   public void transformWithFieldResolverParentIsAnInterfaceThrowsException() {
     // GIVEN
     XtextGraph xtextGraph = createTestXtextGraph(SCHEMA_A_IS_INTERFACE);
-    assertThat(xtextGraph.hasFieldResolverDirective()).isFalse();
+    assertThat(xtextGraph.isHasFieldResolverDefinition()).isFalse();
 
     exceptionRule.expect(NotAValidLocationForFieldResolverDirective.class);
 
@@ -160,7 +160,7 @@ public class FieldResolverTransformerPreMergeTest {
   public void transformWithFieldDefinitionResolveHasArgumentThrowsException() {
     // GIVEN
     XtextGraph xtextGraph = createTestXtextGraph(SCHEMA_FIELD_WITH_RESOLVER_HAS_ARGUMENT);
-    assertThat(xtextGraph.hasFieldResolverDirective()).isFalse();
+    assertThat(xtextGraph.isHasFieldResolverDefinition()).isFalse();
 
     exceptionRule.expect(ArgumentDefinitionNotAllowed.class);
 


### PR DESCRIPTION
# What Changed
Create a new optimized implementation for service metadata. Remove XtextGraph usage post schema stitching. 

# Why
The runtime only needs service metadata but we still keep a reference to giant XtextGraph which can be removed. 
This change with separate the RuntimeMetadata and BuildTimeMetadata objects and improve memory usage. 

Todo:

- [ ] Add tests
- [ ] Add docs