### PR TITLE
support for transitioning resolver directive to federation entities

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/federation/EntityTypeMerger.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/federation/EntityTypeMerger.java
@@ -1,25 +1,67 @@
 package com.intuit.graphql.orchestrator.federation;
 
-import static com.intuit.graphql.orchestrator.utils.FederationUtils.isTypeSystemForBaseType;
-import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.getFieldDefinitions;
-import static org.apache.commons.collections4.CollectionUtils.containsAny;
-
 import com.intuit.graphql.graphQL.FieldDefinition;
 import com.intuit.graphql.graphQL.TypeDefinition;
-
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.intuit.graphql.graphQL.TypeSystemDefinition;
+import com.intuit.graphql.orchestrator.xtext.UnifiedXtextGraph;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.intuit.graphql.orchestrator.resolverdirective.FieldResolverDirectiveUtil.RESOLVER_DIRECTIVE_NAME;
+import static com.intuit.graphql.orchestrator.utils.FederationConstants.FEDERATION_EXTERNAL_DIRECTIVE;
+import static com.intuit.graphql.orchestrator.utils.FederationUtils.isTypeSystemForBaseType;
+import static com.intuit.graphql.orchestrator.utils.FederationUtils.isTypeSystemForExtensionType;
+import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.getFieldDefinitions;
+import static com.intuit.graphql.orchestrator.utils.XtextUtils.definitionContainsDirective;
+import static org.apache.commons.collections4.CollectionUtils.containsAny;
+
 public class EntityTypeMerger {
 
-  public TypeDefinition mergeIntoBaseType(EntityMergingContext entityMergingContext) {
+  public TypeDefinition mergeIntoBaseType(EntityMergingContext entityMergingContext, UnifiedXtextGraph unifiedXtextGraph) {
+    pruneConflictingResolverInfo(entityMergingContext, unifiedXtextGraph);
     merge(entityMergingContext);
     return entityMergingContext.getBaseType();
+  }
+
+  private void pruneConflictingResolverInfo(EntityMergingContext entityMergingContext, UnifiedXtextGraph unifiedXtextGraph) {
+    List<FieldDefinition> entityFieldDefinitions = null;
+
+    if(isTypeSystemForExtensionType(entityMergingContext.getExtensionSystemDefinition())) {
+      entityFieldDefinitions = getFieldDefinitions(entityMergingContext.getExtensionSystemDefinition().getTypeExtension());
+    } else {
+      entityFieldDefinitions = getFieldDefinitions(entityMergingContext.getExtensionSystemDefinition().getType());
+    }
+
+    entityFieldDefinitions.forEach(entityFieldDefinition -> {
+      String entityFieldName = entityFieldDefinition.getName();
+
+      if((definitionContainsDirective(entityFieldDefinition, FEDERATION_EXTERNAL_DIRECTIVE))) {
+        //remove field resolver meta data
+        getFieldDefinitions(entityMergingContext.getBaseType())
+                .removeIf(preexistingField -> definitionContainsDirective(preexistingField, RESOLVER_DIRECTIVE_NAME)
+                && preexistingField.getName().equals(entityFieldName));
+
+        unifiedXtextGraph.getFieldResolverContexts().removeIf(fieldResolverContext ->
+                fieldResolverContext.getParentTypename().equals(entityMergingContext.getTypename()) &&
+                        fieldResolverContext.getFieldName().equals(entityFieldName));
+      } else {
+          //remove field from entity metadata created during FederationTransformerPreMerge for the resolvers namespace
+          unifiedXtextGraph.getFederationMetadataByNamespace()
+          .entrySet()
+          .stream()
+          .filter(entrySet -> !entrySet.getKey().equals(entityMergingContext.getServiceNamespace()))
+          .map(Map.Entry::getValue)
+          .map(federationMetadata -> federationMetadata.getEntityMetadataByName(entityMergingContext.getTypename()))
+          .filter(Objects::nonNull)
+          .forEach(entityMetadata -> entityMetadata.getFields().remove(entityFieldName));
+      }
+    });
   }
 
   private void merge(EntityMergingContext entityMergingContext) {

--- a/src/main/java/com/intuit/graphql/orchestrator/schema/fold/UnifiedXtextGraphFolder.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/schema/fold/UnifiedXtextGraphFolder.java
@@ -8,13 +8,19 @@ import com.intuit.graphql.orchestrator.schema.type.conflict.resolver.XtextTypeCo
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import com.intuit.graphql.orchestrator.xtext.FieldContext;
-import com.intuit.graphql.orchestrator.xtext.XtextGraph;
 import com.intuit.graphql.orchestrator.xtext.UnifiedXtextGraph;
+import com.intuit.graphql.orchestrator.xtext.XtextGraph;
 import com.intuit.graphql.utils.XtextTypeUtils;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.intuit.graphql.orchestrator.schema.fold.FieldMergeValidations.checkMergeEligibility;

--- a/src/main/java/com/intuit/graphql/orchestrator/stitching/XtextStitcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/stitching/XtextStitcher.java
@@ -334,9 +334,9 @@ public class XtextStitcher implements Stitcher {
      */
     private List<Transformer<UnifiedXtextGraph, UnifiedXtextGraph>> defaultPostMergeTransformers() {
       return Arrays.asList(
+          new FederationTransformerPostMerge(),
           new ResolverArgumentTransformer(),
           new FieldResolverTransformerPostMerge(),
-          new FederationTransformerPostMerge(),
           new GraphQLAdapterTransformer()
       );
     }

--- a/src/test/java/com/intuit/graphql/orchestrator/federation/EntityTypeMergerTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/federation/EntityTypeMergerTest.java
@@ -1,26 +1,39 @@
 package com.intuit.graphql.orchestrator.federation;
 
+import com.google.common.collect.Sets;
 import com.intuit.graphql.graphQL.FieldDefinition;
 import com.intuit.graphql.graphQL.ObjectTypeDefinition;
 import com.intuit.graphql.graphQL.ObjectTypeExtensionDefinition;
 import com.intuit.graphql.graphQL.TypeDefinition;
 import com.intuit.graphql.graphQL.TypeSystemDefinition;
 import com.intuit.graphql.orchestrator.federation.EntityTypeMerger.EntityMergingContext;
+import com.intuit.graphql.orchestrator.federation.metadata.FederationMetadata;
+import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext;
 import com.intuit.graphql.orchestrator.xtext.UnifiedXtextGraph;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import static com.intuit.graphql.orchestrator.XtextObjectCreationUtil.buildDirective;
+import static com.intuit.graphql.orchestrator.XtextObjectCreationUtil.buildDirectiveDefinition;
 import static com.intuit.graphql.orchestrator.XtextObjectCreationUtil.buildFieldDefinition;
 import static com.intuit.graphql.orchestrator.XtextObjectCreationUtil.buildObjectTypeDefinition;
 import static com.intuit.graphql.orchestrator.XtextObjectCreationUtil.buildObjectTypeExtensionDefinition;
 import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.getFieldDefinitions;
 import static com.intuit.graphql.orchestrator.xtext.GraphQLFactoryDelegate.createTypeSystemDefinition;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -76,6 +89,92 @@ public class EntityTypeMergerTest {
     assertThat(actual).isSameAs(baseObjectType);
     List<FieldDefinition> actualFieldDefinitions = getFieldDefinitions(actual);
     assertThat(actualFieldDefinitions).hasSize(2);
+  }
+
+  @Test
+  public void mergeIntoBaseType_prunesFieldResolverInfo_success(){
+    TypeSystemDefinition typeSystemDefinition = createTypeSystemDefinition();
+
+    FieldDefinition resolverRequiredField = buildFieldDefinition("requiredField");
+
+    FieldDefinition entityRequiredField = buildFieldDefinition("requiredField");
+    entityRequiredField.getDirectives().add(buildDirective(buildDirectiveDefinition("external"), emptyList()));
+
+    FieldDefinition conflictingFieldResolver1 = buildFieldDefinition("testField2");
+
+    FieldDefinition fieldResolver2  = buildFieldDefinition("ExternalFieldResolver");
+
+
+    ObjectTypeDefinition baseObjectType =
+            buildObjectTypeDefinition("EntityType", Arrays.asList(
+                    TEST_FIELD_DEFINITION_1,
+                    resolverRequiredField,
+                    conflictingFieldResolver1,
+                    fieldResolver2
+            ));
+
+    ObjectTypeExtensionDefinition objectTypeExtension =
+            buildObjectTypeExtensionDefinition("EntityType", Arrays.asList(
+                    entityRequiredField,
+                    TEST_FIELD_DEFINITION_2
+            ));
+
+    typeSystemDefinition.setTypeExtension(objectTypeExtension);
+
+    when(entityMergingContextMock.getBaseType()).thenReturn(baseObjectType);
+    when(entityMergingContextMock.getExtensionSystemDefinition()).thenReturn(typeSystemDefinition);
+
+    List<FieldResolverContext> fieldResolverContexts = new ArrayList();
+    fieldResolverContexts.add(
+      FieldResolverContext.builder()
+        .parentTypeDefinition(baseObjectType)
+        .fieldDefinition(conflictingFieldResolver1)
+        .build()
+    );
+    fieldResolverContexts.add(
+      FieldResolverContext.builder()
+        .parentTypeDefinition(baseObjectType)
+        .fieldDefinition(fieldResolver2)
+        .build()
+    );
+
+    when(unifiedXtextGraphMock.getFieldResolverContexts()).thenReturn(fieldResolverContexts);
+
+    Map<String, FederationMetadata> federationMetadataMap = new HashMap<>();
+
+    FederationMetadata baseFederationMetadataMock = mock(FederationMetadata.class);
+    FederationMetadata extFederationMetadataMock = mock(FederationMetadata.class);
+
+    FederationMetadata.EntityMetadata baseEntityMetaDataMock = mock(FederationMetadata.EntityMetadata.class);
+    Set<String> baseFields = Sets.newHashSet("requiredField", "testField2", "ExternalFieldResolver");
+    when(baseEntityMetaDataMock.getFields()).thenReturn(baseFields);
+
+    FederationMetadata.EntityMetadata extEntityMetaDataMock = mock(FederationMetadata.EntityMetadata.class);
+    Set<String> extFields = Sets.newHashSet( "testField2");
+    when(extEntityMetaDataMock.getFields()).thenReturn(extFields);
+
+    when(baseFederationMetadataMock.getEntityMetadataByName("EntityType")).thenReturn(baseEntityMetaDataMock);
+    when(extFederationMetadataMock.getEntityMetadataByName("EntityType")).thenReturn(extEntityMetaDataMock);
+
+    federationMetadataMap.put("baseService", baseFederationMetadataMock);
+    federationMetadataMap.put("extService", extFederationMetadataMock);
+
+    when(unifiedXtextGraphMock.getFederationMetadataByNamespace()).thenReturn(federationMetadataMap);
+    when(entityMergingContextMock.getTypename()).thenReturn("EntityType");
+    TypeDefinition actual = subjectUnderTest.mergeIntoBaseType(entityMergingContextMock, unifiedXtextGraphMock);
+
+    assertThat(actual).isSameAs(baseObjectType);
+    List<FieldDefinition> actualFieldDefinitions = getFieldDefinitions(actual);
+    assertThat(actualFieldDefinitions).hasSize(4);
+
+    assertThat(fieldResolverContexts.size()).isEqualTo(1);
+    assertThat(fieldResolverContexts.get(0).getFieldName()).isEqualTo("ExternalFieldResolver");
+
+    assertThat(baseFields.size()).isEqualTo(2);
+    assertThat(baseFields).contains("requiredField", "ExternalFieldResolver");
+
+    assertThat(actualFieldDefinitions.stream().map(FieldDefinition::getName).collect(Collectors.toList()))
+            .contains("requiredField", "testField2", "ExternalFieldResolver", "testField1");
   }
 
   public void mergeIntoBaseType_interfaceTypeDefinition_success() {

--- a/src/test/java/com/intuit/graphql/orchestrator/federation/EntityTypeMergerTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/federation/EntityTypeMergerTest.java
@@ -1,5 +1,19 @@
 package com.intuit.graphql.orchestrator.federation;
 
+import com.intuit.graphql.graphQL.FieldDefinition;
+import com.intuit.graphql.graphQL.ObjectTypeDefinition;
+import com.intuit.graphql.graphQL.ObjectTypeExtensionDefinition;
+import com.intuit.graphql.graphQL.TypeDefinition;
+import com.intuit.graphql.graphQL.TypeSystemDefinition;
+import com.intuit.graphql.orchestrator.federation.EntityTypeMerger.EntityMergingContext;
+import com.intuit.graphql.orchestrator.xtext.UnifiedXtextGraph;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
 import static com.intuit.graphql.orchestrator.XtextObjectCreationUtil.buildFieldDefinition;
 import static com.intuit.graphql.orchestrator.XtextObjectCreationUtil.buildObjectTypeDefinition;
 import static com.intuit.graphql.orchestrator.XtextObjectCreationUtil.buildObjectTypeExtensionDefinition;
@@ -9,20 +23,6 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.when;
 
-import com.intuit.graphql.graphQL.FieldDefinition;
-import com.intuit.graphql.graphQL.ObjectTypeDefinition;
-import com.intuit.graphql.graphQL.ObjectTypeExtensionDefinition;
-import com.intuit.graphql.graphQL.TypeDefinition;
-import com.intuit.graphql.graphQL.TypeSystemDefinition;
-import com.intuit.graphql.orchestrator.federation.EntityTypeMerger.EntityMergingContext;
-
-import java.util.List;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
 @RunWith(MockitoJUnitRunner.class)
 public class EntityTypeMergerTest {
 
@@ -30,6 +30,7 @@ public class EntityTypeMergerTest {
   private static final FieldDefinition TEST_FIELD_DEFINITION_2 = buildFieldDefinition("testField2");
 
   @Mock private EntityMergingContext entityMergingContextMock;
+  @Mock private UnifiedXtextGraph unifiedXtextGraphMock;
 
   private EntityTypeMerger subjectUnderTest = new EntityTypeMerger();
 
@@ -48,7 +49,7 @@ public class EntityTypeMergerTest {
     when(entityMergingContextMock.getBaseType()).thenReturn(baseObjectType);
     when(entityMergingContextMock.getExtensionSystemDefinition()).thenReturn(typeSystemDefinition);
 
-    TypeDefinition actual = subjectUnderTest.mergeIntoBaseType(entityMergingContextMock);
+    TypeDefinition actual = subjectUnderTest.mergeIntoBaseType(entityMergingContextMock, unifiedXtextGraphMock);
 
     assertThat(actual).isSameAs(baseObjectType);
     List<FieldDefinition> actualFieldDefinitions = getFieldDefinitions(actual);
@@ -70,7 +71,7 @@ public class EntityTypeMergerTest {
     when(entityMergingContextMock.getBaseType()).thenReturn(baseObjectType);
     when(entityMergingContextMock.getExtensionSystemDefinition()).thenReturn(typeSystemDefinition);
 
-    TypeDefinition actual = subjectUnderTest.mergeIntoBaseType(entityMergingContextMock);
+    TypeDefinition actual = subjectUnderTest.mergeIntoBaseType(entityMergingContextMock, unifiedXtextGraphMock);
 
     assertThat(actual).isSameAs(baseObjectType);
     List<FieldDefinition> actualFieldDefinitions = getFieldDefinitions(actual);


### PR DESCRIPTION
# What Changed
Allows both resolver and entity support, but ignore resolver and removes metadata if entity support exists.
Resolves #95 

Todo:

- [ ] Add tests
- [ ] Add docs